### PR TITLE
Fix pave numeric path bug

### DIFF
--- a/src/lib/pave/index.js
+++ b/src/lib/pave/index.js
@@ -15,16 +15,16 @@ export default (obj, path, value) => {
   const objNew = JSON.parse(JSON.stringify(obj));
   let objMutating = objNew;
 
+  const isNumeric = (str) => /^\d+$/.test(str);
+
   for (let i = 0; i < keys.length; i += 1) {
-    const key = Number.isNaN(parseInt(keys[i], 10))
-      ? keys[i]
-      : parseInt(keys[i], 10);
+    const key = isNumeric(keys[i]) ? parseInt(keys[i], 10) : keys[i];
 
     if (i === keys.length - 1) {
       objMutating[key] = value;
     } else {
       if (!objMutating[key]) {
-        objMutating[key] = Number.isNaN(parseInt(keys[i + 1], 10)) ? {} : [];
+        objMutating[key] = isNumeric(keys[i + 1]) ? [] : {};
       }
       objMutating = objMutating[key];
     }

--- a/src/lib/pave/index.spec.js
+++ b/src/lib/pave/index.spec.js
@@ -53,6 +53,11 @@ const examples = [
     inputs: { obj: {}, path: 'a', value: 42 },
     want: { result: { a: 42 } },
   },
+  {
+    name: 'Handle numeric-like string keys',
+    inputs: { obj: {}, path: 'a.1b.c', value: 42 },
+    want: { result: { a: { '1b': { c: 42 } } } },
+  },
 ];
 
 describe('pave', () => {


### PR DESCRIPTION
## Summary
- handle numeric-like string keys in `pave`
- add regression test for `pave`

## Testing
- `npx vitest run src/lib/pave/index.spec.js`
- `npm test` *(fails: OPENAI_API_KEY missing)*