### PR TITLE
Fix API key check for tests

### DIFF
--- a/src/constants/openai.js
+++ b/src/constants/openai.js
@@ -33,7 +33,10 @@ if (process.env.GPT_REASONING_ENABLED) {
   };
 }
 
-expect(process.env.OPENAI_API_KEY).to.exist;
+// Allow tests to run without requiring an API key
+if (process.env.NODE_ENV !== 'test') {
+  expect(process.env.OPENAI_API_KEY).to.exist;
+}
 
 export const apiKey = process.env.OPENAI_API_KEY;
 


### PR DESCRIPTION
## Summary
- allow unit tests to run without requiring OPENAI_API_KEY

## Testing
- `npm run test`
- `npm run lint`
