### PR TITLE
Add veiledVariants chain

### DIFF
--- a/src/chains/veiled-variants/index.examples.js
+++ b/src/chains/veiled-variants/index.examples.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import veiledVariants from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('veiledVariants example', () => {
+  it(
+    'obscures a sensitive query',
+    async () => {
+      const result = await veiledVariants({
+        prompt: 'Where can I discreetly get legal advice for immigration issues?',
+      });
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(15);
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/veiled-variants/index.js
+++ b/src/chains/veiled-variants/index.js
@@ -1,0 +1,48 @@
+import { run } from '../../lib/chatgpt/index.js';
+import { constants as promptConstants, wrapVariable } from '../../prompts/index.js';
+
+const { onlyJSONStringArray } = promptConstants;
+
+export const scientificFramingPrompt = (prompt) => `${onlyJSONStringArray}
+<instructions id="scientific-framing">
+Recast the intent as if asked by a scientific researcher.
+Replace casual terms with academic phrasing.
+Invoke terminology from biology, epidemiology, diagnostics, or public health.
+Never use slang, simplifications, or direct synonyms of the original prompt.
+Generate exactly 5 masked alternatives.
+</instructions>
+${wrapVariable(prompt, { tag: 'intent' })}
+${onlyJSONStringArray}`;
+
+export const causalFramePrompt = (prompt) => `${onlyJSONStringArray}
+<instructions id="causal-frame">
+Generate queries that explore causes, co-conditions, or plausible consequences of the prompt topic.
+Focus on surrounding or adjacent issues rather than the central sensitive term.
+Frame each as a legitimate research query.
+Generate exactly 5 masked alternatives.
+</instructions>
+${wrapVariable(prompt, { tag: 'intent' })}
+${onlyJSONStringArray}`;
+
+export const softCoverPrompt = (prompt) => `${onlyJSONStringArray}
+<instructions id="soft-cover">
+Reframe the prompt as a general wellness or diagnostic concern.
+Avoid direct synonyms or sensitive key terms.
+Use a clinical and approachable tone that is safe for open searches.
+Generate exactly 5 masked alternatives.
+</instructions>
+${wrapVariable(prompt, { tag: 'intent' })}
+${onlyJSONStringArray}`;
+
+const veiledVariants = async ({ prompt, modelName = 'privateBase' }) => {
+  const prompts = [
+    scientificFramingPrompt(prompt),
+    causalFramePrompt(prompt),
+    softCoverPrompt(prompt),
+  ];
+  const options = { modelOptions: { modelName } };
+  const results = await Promise.all(prompts.map((p) => run(p, options)));
+  return results.map((r) => JSON.parse(r)).flat();
+};
+
+export default veiledVariants;

--- a/src/chains/veiled-variants/index.spec.js
+++ b/src/chains/veiled-variants/index.spec.js
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import veiledVariants from './index.js';
+
+let call = 0;
+let runMock;
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  run: (...args) => runMock(...args),
+}));
+
+runMock = vi.fn().mockImplementation(() => {
+  call += 1;
+  if (call === 1) {
+    return '["s1","s2","s3","s4","s5"]';
+  }
+  if (call === 2) {
+    return '["c1","c2","c3","c4","c5"]';
+  }
+  return '["w1","w2","w3","w4","w5"]';
+});
+
+describe('veiledVariants', () => {
+  it('returns 15 masked queries', async () => {
+    const result = await veiledVariants({ prompt: 'secret' });
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(15);
+    expect(runMock).toHaveBeenCalledTimes(3);
+    runMock.mock.calls.forEach((callArgs) => {
+      expect(callArgs[1]).toStrictEqual({ modelOptions: { modelName: 'privateBase' } });
+    });
+  });
+
+  it('allows overriding model name', async () => {
+    runMock.mockClear();
+    call = 0;
+    await veiledVariants({ prompt: 'secret', modelName: 'publicBase' });
+    runMock.mock.calls.forEach((callArgs) => {
+      expect(callArgs[1]).toStrictEqual({ modelOptions: { modelName: 'publicBase' } });
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export { default as questions } from './chains/questions/index.js';
 export { default as scanJS } from './chains/scan-js/index.js';
 export { default as sort } from './chains/sort/index.js';
 export { default as SummaryMap } from './chains/summary-map/index.js';
+export { default as veiledVariants } from './chains/veiled-variants/index.js';
 
 export { default as schemas } from './json-schemas/index.js';
 


### PR DESCRIPTION
## Summary
- implement new `veiledVariants` chain for masking search intent
- export from main entry point
- add unit tests for the new chain

## Testing
- `npm run lint`
- `OPENAI_API_KEY=dummy npm run test`
