### PR TITLE
Add repository guide details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,63 @@
 # Verblets
 
-Verblets rebuild the basic operations of software with language model intelligence. Each verblet takes a combination of natural language and structured input and returns structured data. Like applications, verblets are powerful utilities on their own, or they can be strategically applied to in traditional software.  
+Verblets rebuild the basic operations of software with language model intelligence. Each verblet takes a combination of natural language and structured input and returns structured data. Like applications, verblets are powerful utilities on their own, or they can be strategically applied to in traditional software.
+
+## Repository Guide
+
+### Quick Links
+
+- [Verblets](./src/verblets/README.md)
+- [Chains](./src/chains/README.md)
+- [Prompts](./src/prompts/README.md)
+- [JSON Schemas](./src/json-schemas/README.md)
+- [Library Helpers](./src/lib/README.md)
+
+### Chains
+
+- [anonymize](./src/chains/anonymize) - scrub personal details from text
+- [dismantle](./src/chains/dismantle) - break systems into components
+- [list](./src/chains/list) - generate contextual lists
+- [questions](./src/chains/questions) - produce clarifying questions
+- [scan-js](./src/chains/scan-js) - analyze code quality
+- [sort](./src/chains/sort) - order lists by any criteria
+- [summary-map](./src/chains/summary-map) - summarize a collection
+- [test](./src/chains/test) - run LLM-driven tests
+- [test-advice](./src/chains/test-advice) - get feedback on test coverage
+
+### Verblets
+
+- [auto](./src/verblets/auto) - automatically select the best verblet
+- [bool](./src/verblets/bool) - interpret text as a boolean
+- [enum](./src/verblets/enum) - map text to predefined options
+- [intent](./src/verblets/intent) - extract user intent
+- [number](./src/verblets/number) - parse numeric values
+- [number-with-units](./src/verblets/number-with-units) - parse numbers with units
+- [schema-org](./src/verblets/schema-org) - create schema.org objects
+- [to-object](./src/verblets/to-object) - convert descriptions to objects
+
+### Library Helpers
+
+- [chatgpt](./src/lib/chatgpt) - OpenAI ChatGPT wrapper
+- [prompt-cache](./src/lib/prompt-cache) - cache prompts and responses
+- [retry](./src/lib/retry) - retry asynchronous calls
+- [search-best-first](./src/lib/search-best-first) - best-first search
+- [search-js-files](./src/lib/search-js-files) - scan JavaScript sources
+- [shorten-text](./src/lib/shorten-text) - shorten text using a model
+- [strip-numeric](./src/lib/strip-numeric) - remove non-digit characters
+- [strip-response](./src/lib/strip-response) - clean up model responses
+- [to-bool](./src/lib/to-bool) - parse text to boolean
+- [to-enum](./src/lib/to-enum) - parse text to enum values
+- [to-number](./src/lib/to-number) - parse text to numbers
+- [to-number-with-units](./src/lib/to-number-with-units) - parse numbers with units
+- [transcribe](./src/lib/transcribe) - microphone transcription via Whisper
+
+### JSON Schemas
+
+Sample schemas for testing live in [`src/json-schemas`](./src/json-schemas/README.md).
+
+### Prompts
+
+Prompt builders and text snippets live in [`src/prompts`](./src/prompts/README.md).
 
 ## Examples
 

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -1,0 +1,17 @@
+# Chains
+
+Chains orchestrate multiple verblets or helper functions to perform more complex tasks. Each subdirectory exposes a specific workflow that can be imported as a single function.
+
+Available chains:
+
+- [anonymize](./anonymize)
+- [dismantle](./dismantle)
+- [list](./list)
+- [questions](./questions)
+- [scan-js](./scan-js)
+- [sort](./sort)
+- [summary-map](./summary-map)
+- [test](./test)
+- [test-advice](./test-advice)
+
+Chains are free to use any utilities from [`../lib`](../lib/README.md) and often rely on one or more verblets from [`../verblets`](../verblets/README.md).

--- a/src/json-schemas/README.md
+++ b/src/json-schemas/README.md
@@ -1,0 +1,13 @@
+# JSON Schemas
+
+This folder contains example schemas used throughout the project. Schemas are referenced by certain verblets and chains for validating or shaping structured output.
+
+Included files:
+
+- `cars-test.json`
+- `intent.json`
+- `schema-dot-org-photograph.json`
+- `schema-dot-org-place.json`
+- `index.js` – helper that loads a subset of schemas for quick access.
+
+Additional schemas may live alongside the modules that use them (for example in `../verblets` or `../chains`).

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -1,0 +1,22 @@
+# Library Helpers
+
+The `lib` directory houses reusable utilities used by verblets and chains. Each subfolder contains a focused helper function or class.
+
+Modules include:
+
+<!-- commonly used utilities -->
+- [chatgpt](./chatgpt) – wrapper around OpenAI's ChatGPT API.
+- [prompt-cache](./prompt-cache) – cache prompts/responses locally.
+- [retry](./retry) – generic async retry helper.
+- [search-best-first](./search-best-first) – best-first tree search algorithm.
+- [search-js-files](./search-js-files) – locate and analyze JavaScript files.
+- [shorten-text](./shorten-text) – shorten text using an LLM.
+- [strip-numeric](./strip-numeric) – remove non-digit characters.
+- [strip-response](./strip-response) – clean up model responses.
+- [to-bool](./to-bool) – parse text into a boolean.
+- [to-enum](./to-enum) – parse text into an enum value.
+- [to-number](./to-number) – parse text into a number.
+- [to-number-with-units](./to-number-with-units) – parse numbers that include units.
+- [transcribe](./transcribe) – microphone transcription via Whisper.
+
+These helpers are building blocks used throughout the rest of the project.

--- a/src/prompts/README.md
+++ b/src/prompts/README.md
@@ -12,4 +12,6 @@ The functions can generate HTML from their inputs and this structure can be tran
 
 # Constants
 
-Currently it's reasonable to keep the text fragments needed for building prompts in a single constants.js file. It's forseable that the number of text fragments will grow. At that point, it would make sense to maintain them with a CMS such as Strapi.
+The text snippets used by many prompt functions are collected in
+[`constants.js`](./constants.js). As the set of fragments grows it may make sense
+to manage them with a CMS such as Strapi.

--- a/src/verblets/README.md
+++ b/src/verblets/README.md
@@ -1,0 +1,16 @@
+# Verblets
+
+The `verblets` directory contains individual utilities that wrap specific language-model workflows. Each verblet exports a single function and usually includes its own examples, tests and optional JSON schema.
+
+Available verblets:
+
+- [auto](./auto)
+- [bool](./bool)
+- [enum](./enum)
+- [intent](./intent)
+- [number](./number)
+- [number-with-units](./number-with-units)
+- [schema-org](./schema-org)
+- [to-object](./to-object) – see its [README](./to-object/README.md) for details.
+
+Use these modules directly or compose them inside [chains](../chains/README.md).


### PR DESCRIPTION
## Summary
- restore module lists in the root Repository Guide
- trim `src/lib/README.md` to show only supported helpers

## Testing
- `npm run lint`
- `npm run test` *(skipped: docs only)*