### PR TITLE
Add speak/listen utilities and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-slim
+
+RUN apt-get update && apt-get install -y python3 python3-pip ffmpeg sox && \
+    pip3 install --no-cache-dir TTS
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+CMD ["node"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 version: '3.8'
 
 services:
+  app:
+    build: .
+    volumes:
+      - .:/app
+    command: npm run dev
   redis:
     image: 'redis:latest'
     ports:

--- a/scripts/voice-runner/README.md
+++ b/scripts/voice-runner/README.md
@@ -1,0 +1,9 @@
+# Voice Runner
+
+A simple CLI that lets you control Verblets with voice commands. Press `r` to start or stop recording and `q` to quit. Recorded audio is transcribed and passed through the intent system just like the simple editor.
+
+Run with:
+
+```bash
+npm run script -- voice-runner
+```

--- a/scripts/voice-runner/index.js
+++ b/scripts/voice-runner/index.js
@@ -1,0 +1,57 @@
+import dotenv from 'dotenv/config';
+import readline from 'node:readline';
+import chatGPT, { auto, bool, getRedis } from '../../src/index.js';
+import Transcriber from '../../src/lib/transcribe/index.js';
+
+const operations = [
+  {
+    name: 'bool',
+    fn: ({ text }) => bool(text, { forceQuery: true })
+  }
+];
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+console.error('Press "r" to start/stop recording. Press "q" to quit.');
+
+let transcriber;
+let recordingPromise;
+let recording = false;
+
+async function handleText(text) {
+  const intentFound = await auto(text, { forceQuery: true });
+  const op = operations.find(option => option.name === intentFound.name);
+  if (op) {
+    const result = await op.fn(...intentFound.functionArgsAsArray);
+    console.error(result);
+  } else {
+    const result = await chatGPT(text);
+    console.error(result);
+  }
+}
+
+rl.on('line', async (input) => {
+  const key = input.trim().toLowerCase();
+  if (key === 'q') {
+    rl.close();
+    if (transcriber && recording) {
+      transcriber.stopRecording();
+      await recordingPromise;
+    }
+    await (await getRedis()).disconnect();
+    process.exit(0);
+  } else if (key === 'r') {
+    if (!recording) {
+      transcriber = new Transcriber('');
+      console.error('Recording...');
+      recordingPromise = transcriber.startRecording();
+      recording = true;
+    } else {
+      transcriber.stopRecording();
+      const text = await recordingPromise;
+      console.error(`\nHeard: ${text}`);
+      await handleText(text);
+      console.error('\nPress "r" to record again, "q" to quit.');
+      recording = false;
+    }
+  }
+});

--- a/src/index.js
+++ b/src/index.js
@@ -30,5 +30,8 @@ export { default as intent } from './verblets/intent/index.js';
 export { default as number } from './verblets/number/index.js';
 export { default as schemaOrg } from './verblets/schema-org/index.js';
 export { default as toObject } from './verblets/to-object/index.js';
+export { default as Transcriber } from './lib/transcribe/index.js';
+export { default as speak } from './lib/speak/index.js';
+export { default as listen } from './lib/listen/index.js';
 
 export default chatGPT;

--- a/src/lib/listen/index.js
+++ b/src/lib/listen/index.js
@@ -1,0 +1,29 @@
+import os from 'node:os';
+import path from 'node:path';
+import fsPromises from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+
+const defaultCommands = [
+  (duration, file) =>
+    `ffmpeg -y -f pulse -i default -t ${duration} -ac 1 -ar 16000 -c:a pcm_s16le ${file}`,
+  (duration, file) => `sox -d -c 1 -b 16 -r 16000 ${file} trim 0 ${duration}`,
+  (duration, file) => `arecord -d ${duration} -f cd -t wav ${file}`,
+];
+
+export default async function listen({ duration = 3, cacheDir, commands = defaultCommands } = {}) {
+  const dir =
+    cacheDir ||
+    process.env.VERBLETS_CACHE_DIR ||
+    path.join(process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache'), 'verblets');
+  await fsPromises.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `recording-${Date.now()}.wav`);
+
+  for (const build of commands) {
+    const cmd = build(duration, filePath);
+    const result = spawnSync(cmd, { shell: true, stdio: 'ignore' });
+    if (!result.error && result.status === 0) {
+      return filePath;
+    }
+  }
+  throw new Error('No recording command succeeded');
+}

--- a/src/lib/listen/index.spec.js
+++ b/src/lib/listen/index.spec.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import listen from './index.js';
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(() => ({ status: 0 })),
+}));
+
+describe('listen', () => {
+  const cacheDir = path.join(os.tmpdir(), 'listen-test');
+
+  beforeEach(async () => {
+    try {
+      await fs.rm(cacheDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('records to cache directory', async () => {
+    const file = await listen({ duration: 1, cacheDir });
+    expect(file.startsWith(cacheDir)).toBe(true);
+    expect(spawnSync).toHaveBeenCalled();
+  });
+
+  it('falls back when first command fails', async () => {
+    spawnSync.mockReset();
+    spawnSync.mockReturnValueOnce({ error: { code: 'ENOENT' } }).mockReturnValueOnce({ status: 0 });
+    const file = await listen({ duration: 1, cacheDir });
+    expect(spawnSync.mock.calls[1][0]).toContain(cacheDir);
+    expect(file.startsWith(cacheDir)).toBe(true);
+  });
+});

--- a/src/lib/speak/index.js
+++ b/src/lib/speak/index.js
@@ -1,0 +1,24 @@
+import { spawnSync } from 'node:child_process';
+
+const defaultCommands = [
+  (text) => `tts --text "${text}"`,
+  (text) => `echo "${text}" | festival --tts`,
+  (text) => `espeak-ng "${text}"`,
+  (text) => `spd-say "${text}"`,
+  (text) => `say "${text}"`,
+  (text) => `espeak "${text}"`,
+];
+
+export default function speak(text, { commands = defaultCommands } = {}) {
+  const list = process.env.VERBLETS_TTS_CMD
+    ? [(t) => `${process.env.VERBLETS_TTS_CMD} "${t}"`]
+    : commands;
+  for (const build of list) {
+    const cmd = build(text);
+    const result = spawnSync(cmd, { shell: true, stdio: 'ignore' });
+    if (!result.error && result.status === 0) {
+      return true;
+    }
+  }
+  throw new Error('No speech command succeeded');
+}

--- a/src/lib/speak/index.spec.js
+++ b/src/lib/speak/index.spec.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import speak from './index.js';
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(() => ({ status: 0 })),
+}));
+
+describe('speak', () => {
+  it('uses the first command by default', () => {
+    speak('hello');
+    expect(spawnSync.mock.calls[0][0]).toContain('tts');
+  });
+
+  it('falls back when command is missing', () => {
+    spawnSync.mockReset();
+    spawnSync.mockReturnValueOnce({ error: { code: 'ENOENT' } }).mockReturnValueOnce({ status: 0 });
+    speak('hello', { commands: [() => 'missing', () => 'second'] });
+    expect(spawnSync.mock.calls[1][0]).toBe('second');
+  });
+});

--- a/src/lib/transcribe/index.js
+++ b/src/lib/transcribe/index.js
@@ -1,57 +1,71 @@
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import whisper from 'whisper-node';
 import record from 'node-record-lpcm16';
 
 export default class Transcriber {
-  constructor(targetWord, silenceDuration = 5000, wordPauseDuration = 2000) {
+  constructor(
+    targetWord,
+    {
+      silenceDuration = 5000,
+      cacheDir = process.env.VERBLETS_CACHE_DIR ||
+        path.join(process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache'), 'verblets'),
+    } = {}
+  ) {
     this.targetWord = targetWord;
     this.silenceDuration = silenceDuration;
-    this.wordPauseDuration = wordPauseDuration;
+    this.cacheDir = cacheDir;
     this.transcription = '';
-    this.lastTranscribedTime = Date.now();
     this.recording = null;
+    this.filePath = null;
+    this._resolve = null;
+    this._reject = null;
   }
 
-  startRecording() {
+  async startRecording() {
+    await fsPromises.mkdir(this.cacheDir, { recursive: true });
+    this.filePath = path.join(this.cacheDir, `recording-${Date.now()}.wav`);
+
     this.recording = record.record({
-      sampleRateHertz: 16000,
-      threshold: 0,
-      recordProgram: 'rec',
-      silence: '5.0',
+      sampleRate: 16000,
+      silence: String(this.silenceDuration / 1000),
+      endOnSilence: true,
+      recorder: 'sox',
+      audioType: 'wav',
     });
 
     const audioStream = this.recording.stream();
-    this.transcribe(audioStream);
+    audioStream.pipe(fs.createWriteStream(this.filePath));
+
+    const promise = new Promise((resolve, reject) => {
+      this._resolve = resolve;
+      this._reject = reject;
+    });
+
+    audioStream.on('error', (err) => {
+      if (this._reject) this._reject(err);
+    });
+
+    this.recording.process.on('close', async () => {
+      try {
+        const transcriptArray = await whisper(this.filePath);
+        const text = transcriptArray.map((line) => line.speech).join(' ');
+        this.transcription = text;
+        if (this._resolve) this._resolve(text);
+      } catch (err) {
+        if (this._reject) this._reject(err);
+      }
+    });
+
+    return promise;
   }
 
   stopRecording() {
     if (this.recording) {
       this.recording.stop();
-    }
-  }
-
-  transcribe(stream) {
-    whisper
-      .transcribeStream(stream, { streaming: true })
-      .then((transcription) => {
-        this.handleTranscription(transcription);
-      })
-      .catch((error) => {
-        console.error(error);
-      });
-  }
-
-  handleTranscription(transcription) {
-    this.transcription += transcription;
-    this.lastTranscribedTime = Date.now();
-
-    if (transcription.includes(this.targetWord)) {
-      setTimeout(() => {
-        this.stopRecording();
-      }, this.wordPauseDuration);
-    }
-
-    if (Date.now() - this.lastTranscribedTime >= this.silenceDuration) {
-      this.stopRecording();
+      this.recording = null;
     }
   }
 

--- a/src/lib/transcribe/index.spec.js
+++ b/src/lib/transcribe/index.spec.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { PassThrough } from 'node:stream';
+import { EventEmitter } from 'node:events';
+
+vi.mock('node-record-lpcm16', () => ({
+  default: {
+    record: vi.fn(() => {
+      const stream = new PassThrough();
+      const rec = {
+        process: new EventEmitter(),
+        stop: vi.fn(() => {
+          stream.end();
+          rec.process.emit('close');
+        }),
+        stream: () => stream,
+      };
+      setImmediate(() => {
+        stream.end();
+        rec.process.emit('close');
+      });
+      return rec;
+    }),
+  },
+}));
+
+vi.mock('whisper-node', () => ({
+  default: vi.fn(async () => [{ speech: 'hello world stop' }]),
+}));
+
+// eslint-disable-next-line import/first
+import Transcriber from './index.js';
+
+describe('Transcriber', () => {
+  const cacheDir = path.join(os.tmpdir(), 'verblets-test');
+
+  beforeEach(async () => {
+    try {
+      await fs.rm(cacheDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('records and transcribes to cache directory', async () => {
+    const transcriber = new Transcriber('', { cacheDir });
+    const textPromise = transcriber.startRecording();
+    const text = await textPromise;
+    expect(text).toBe('hello world stop');
+    const files = await fs.readdir(cacheDir);
+    expect(files.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `speak` helper with TTS fallbacks
- add `listen` helper for audio recording
- export helpers from library index
- include unit tests for new helpers
- create Dockerfile installing Coqui TTS and update compose file

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot read properties of undefined)*