### PR TITLE
Remove legacy model names

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -2,8 +2,7 @@
     "vitest.enable": true,
     "vitest.configPath": ".vitest.config.examples.js",
     "vitest.env": {
-        "EXAMPLES": "true",
-        "GPT_REASONING_ENABLED": "true"
+        "EXAMPLES": "true"
     },
     "testExplorer": {
         "showOnRun": true,

--- a/src/chains/anonymize/index.js
+++ b/src/chains/anonymize/index.js
@@ -71,7 +71,7 @@ const anonymize = async (input) => {
 
   // Stage 1: Remove distinctive content
   const stage1Result = await run(stage1Prompt(text, method, context), {
-    modelOptions: { modelName: 'privateBase' },
+    modelOptions: { modelName: 'privacy' },
   });
 
   if (method === anonymizeMethod.LIGHT) {
@@ -85,7 +85,7 @@ const anonymize = async (input) => {
 
   // Stage 2: Normalize structure and tone
   const stage2Result = await run(stage2Prompt(stage1Result, method), {
-    modelOptions: { modelName: 'privateBase' },
+    modelOptions: { modelName: 'privacy' },
   });
 
   if (method === anonymizeMethod.BALANCED) {
@@ -100,7 +100,7 @@ const anonymize = async (input) => {
 
   // Stage 3: Suppress stylistic patterns
   const stage3Result = await run(stage3Prompt(stage2Result, method), {
-    modelOptions: { modelName: 'privateBase' },
+    modelOptions: { modelName: 'privacy' },
   });
 
   return {

--- a/src/chains/scan-js/index.js
+++ b/src/chains/scan-js/index.js
@@ -68,7 +68,7 @@ const visit = async ({
   await retry(async () => {
     const results = await chatGPT(visitPrompt, {
       modelOptions: {
-        modelName: 'publicBase',
+        modelName: 'fastGood',
       },
     });
 

--- a/src/chains/veiled-variants/index.examples.js
+++ b/src/chains/veiled-variants/index.examples.js
@@ -10,7 +10,7 @@ describe('veiledVariants example', () => {
         prompt: 'Where can I discreetly get legal advice for immigration issues?',
       });
       expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBe(15);
+      expect(result.length, `Saw: "${result.join('", "')}"`).toBe(15);
     },
     longTestTimeout
   );

--- a/src/chains/veiled-variants/index.js
+++ b/src/chains/veiled-variants/index.js
@@ -34,7 +34,7 @@ Generate exactly 5 masked alternatives.
 ${wrapVariable(prompt, { tag: 'intent' })}
 ${onlyJSONStringArray}`;
 
-const veiledVariants = async ({ prompt, modelName = 'privateBase' }) => {
+const veiledVariants = async ({ prompt, modelName = 'privacy' }) => {
   const prompts = [
     scientificFramingPrompt(prompt),
     causalFramePrompt(prompt),

--- a/src/chains/veiled-variants/index.js
+++ b/src/chains/veiled-variants/index.js
@@ -2,6 +2,8 @@ import { run } from '../../lib/chatgpt/index.js';
 import { constants as promptConstants, wrapVariable } from '../../prompts/index.js';
 
 const { onlyJSONStringArray } = promptConstants;
+const commonInstructions =
+  'The size of the output should be proportional to the size of the input.';
 
 export const scientificFramingPrompt = (prompt) => `${onlyJSONStringArray}
 <instructions id="scientific-framing">
@@ -10,6 +12,7 @@ Replace casual terms with academic phrasing.
 Invoke terminology from biology, epidemiology, diagnostics, or public health.
 Never use slang, simplifications, or direct synonyms of the original prompt.
 Generate exactly 5 masked alternatives.
+${commonInstructions}
 </instructions>
 ${wrapVariable(prompt, { tag: 'intent' })}
 ${onlyJSONStringArray}`;
@@ -20,6 +23,7 @@ Generate queries that explore causes, co-conditions, or plausible consequences o
 Focus on surrounding or adjacent issues rather than the central sensitive term.
 Frame each as a legitimate research query.
 Generate exactly 5 masked alternatives.
+${commonInstructions}
 </instructions>
 ${wrapVariable(prompt, { tag: 'intent' })}
 ${onlyJSONStringArray}`;
@@ -30,6 +34,7 @@ Reframe the prompt as a general wellness or diagnostic concern.
 Avoid direct synonyms or sensitive key terms.
 Use a clinical and approachable tone that is safe for open searches.
 Generate exactly 5 masked alternatives.
+${commonInstructions}
 </instructions>
 ${wrapVariable(prompt, { tag: 'intent' })}
 ${onlyJSONStringArray}`;

--- a/src/chains/veiled-variants/index.spec.js
+++ b/src/chains/veiled-variants/index.spec.js
@@ -26,16 +26,16 @@ describe('veiledVariants', () => {
     expect(result.length).toBe(15);
     expect(runMock).toHaveBeenCalledTimes(3);
     runMock.mock.calls.forEach((callArgs) => {
-      expect(callArgs[1]).toStrictEqual({ modelOptions: { modelName: 'privateBase' } });
+      expect(callArgs[1]).toStrictEqual({ modelOptions: { modelName: 'privacy' } });
     });
   });
 
   it('allows overriding model name', async () => {
     runMock.mockClear();
     call = 0;
-    await veiledVariants({ prompt: 'secret', modelName: 'publicBase' });
+    await veiledVariants({ prompt: 'secret', modelName: 'fastGood' });
     runMock.mock.calls.forEach((callArgs) => {
-      expect(callArgs[1]).toStrictEqual({ modelOptions: { modelName: 'publicBase' } });
+      expect(callArgs[1]).toStrictEqual({ modelOptions: { modelName: 'fastGood' } });
     });
   });
 });

--- a/src/constants/models.js
+++ b/src/constants/models.js
@@ -12,7 +12,15 @@ const { expect } = chai;
 const _models = {};
 
 if (process.env.OPENAI_API_KEY) {
-  _models.publicBase = {
+  _models.fastCheap = {
+    endpoint: 'v1/chat/completions',
+    name: 'gpt-3.5-turbo',
+    maxTokens: 4096,
+    requestTimeout: 20000,
+    apiKey: process.env.OPENAI_API_KEY,
+    apiUrl: 'https://api.openai.com/',
+  };
+  _models.fastGood = {
     endpoint: 'v1/chat/completions',
     name: 'gpt-4o',
     maxTokens: 16384,
@@ -20,10 +28,7 @@ if (process.env.OPENAI_API_KEY) {
     apiKey: process.env.OPENAI_API_KEY,
     apiUrl: 'https://api.openai.com/',
   };
-}
-
-if (process.env.GPT_REASONING_ENABLED) {
-  _models.publicReasoning = {
+  _models.reasoning = {
     endpoint: 'v1/chat/completions',
     name: 'gpt-4.1-2025-04-14',
     maxTokens: 16384,

--- a/src/constants/models.js
+++ b/src/constants/models.js
@@ -75,7 +75,7 @@ if (process.env.OPENAI_API_KEY) {
   // Caution!: $1.1-4.4/1M tokens
   // cutoff: 05/2024
   // supports image inputs, moderate speed
-  _models.fastCheapReasoningMulti = { 
+  _models.fastCheapReasoningMulti = {
     endpoint: 'v1/chat/completions',
     name: 'o4-mini-2025-04-16',
     maxContextWindow: 128_000,
@@ -101,18 +101,20 @@ if (process.env.OPENAI_API_KEY) {
   };
 
   // Full matrix with explicit names (no aliases)
+  _models.fastGoodMulti = _models.fastCheapMulti;
   _models.fastGoodCheapMulti = _models.fastGoodMulti; // Default system model
   _models.fastGoodCheap = _models.fastGoodMulti;
   _models.fastMulti = _models.fastGoodMulti;
   _models.fast = _models.fastGoodMulti;
   _models.fastGood = _models.fastGoodMulti;
   _models.fastReasoningMulti = _models.fastCheapReasoningMulti;
-  _models.fastReasoning = _models.fastCheapReasoningMulti; 
+  _models.fastReasoning = _models.fastCheapReasoningMulti;
 
+  // eslint-disable-next-line no-self-assign
   _models.fastCheapMulti = _models.fastCheapMulti;
   _models.fastCheap = _models.fastCheapMulti;
   _models.fastCheapReasoning = _models.fastCheapReasoningMulti;
-  
+
   _models.cheapMulti = _models.fastCheapMulti;
   _models.cheap = _models.fastCheapMulti;
   _models.cheapGoodMulti = _models.fastGoodMulti;
@@ -120,6 +122,7 @@ if (process.env.OPENAI_API_KEY) {
   _models.cheapReasoningMulti = _models.fastCheapReasoningMulti;
   _models.cheapReasoning = _models.fastCheapReasoningMulti;
 
+  // eslint-disable-next-line no-self-assign
   _models.goodMulti = _models.goodMulti; // Caution: Moderate cost
   _models.good = _models.goodMulti; // Caution: Moderate cost
 

--- a/src/constants/models.js
+++ b/src/constants/models.js
@@ -11,46 +11,136 @@ const { expect } = chai;
 // eslint-disable-next-line no-underscore-dangle
 const _models = {};
 
+const systemPrompt = `You are a superintelligent processing unit, answering prompts with precise instructions.
+You are a small but critical component in a complex system, so your role in giving quality outputs to your given inputs and instructions is critical. 
+You must obey those instructions to the letter at all costs--do not deviate or add your own interpretation or flair. Stick to the instructions. 
+Aim to be direct, accurate, correct, and concise.
+You'll often be given complex inputs alongside your instructions. Consider the inputs carefully and think through your answer in relation to the inputs and instructions.
+Most prompts will ask for a specific output format, so comply with those details exactly as well.`;
+
 if (process.env.OPENAI_API_KEY) {
-  _models.fastCheap = {
-    endpoint: 'v1/chat/completions',
-    name: 'gpt-3.5-turbo',
-    maxTokens: 4096,
-    requestTimeout: 20000,
-    apiKey: process.env.OPENAI_API_KEY,
-    apiUrl: 'https://api.openai.com/',
-  };
-  _models.fastGood = {
+  // // $0.10-0.40/1M tokens
+  // // cutoff: 5/2024
+  // // supports image inputs, very high speed, 1M token context, 32K output
+  // // low intelligence, but > 3.5 turbo
+  // _models.fastCheapMulti = {
+  //   endpoint: 'v1/chat/completions',
+  //   name: 'gpt-4.1-nano-2025-04-14',
+  //   maxContextWindow: 1_047_576,
+  //   maxOutputTokens: 32_768,
+  //   requestTimeout: 20_000,
+  //   apiKey: process.env.OPENAI_API_KEY,
+  //   apiUrl: 'https://api.openai.com/',
+  //   systemPrompt,
+  // };
+
+  // // $.40-$1.60/1M tokens
+  // // cutoff: 05/2024
+  // // supports image inputs, high speed, 1M token context, 32K output
+  // _models.fastGoodMulti = {
+  //   endpoint: 'v1/chat/completions',
+  //   name: 'gpt-4.1-mini-2025-04-14',
+  //   maxContextWindow: 1_047_576,
+  //   maxOutputTokens: 32_768,
+  //   requestTimeout: 20_000,
+  //   apiKey: process.env.OPENAI_API_KEY,
+  //   apiUrl: 'https://api.openai.com/',
+  //   systemPrompt,
+  // };
+  _models.fastCheapMulti = {
     endpoint: 'v1/chat/completions',
     name: 'gpt-4o',
-    maxTokens: 16384,
-    requestTimeout: 40000,
+    maxContextWindow: 128_000,
+    maxOutputTokens: 16_384,
+    requestTimeout: 20_000,
     apiKey: process.env.OPENAI_API_KEY,
     apiUrl: 'https://api.openai.com/',
+    systemPrompt,
   };
-  _models.reasoning = {
+
+  // $2.5-$10.00/1M tokens
+  // cutoff: 09/2023
+  // supports image inputs, moderate speed
+  _models.goodMulti = {
     endpoint: 'v1/chat/completions',
-    name: 'gpt-4.1-2025-04-14',
-    maxTokens: 16384,
-    requestTimeout: 50000,
+    name: 'gpt-4o-2024-11-20',
+    maxContextWindow: 128_000,
+    maxOutputTokens: 16_384,
+    requestTimeout: 20_000,
     apiKey: process.env.OPENAI_API_KEY,
     apiUrl: 'https://api.openai.com/',
+    systemPrompt,
   };
+
+  // Caution!: $1.1-4.4/1M tokens
+  // cutoff: 05/2024
+  // supports image inputs, moderate speed
+  _models.fastCheapReasoningMulti = { 
+    endpoint: 'v1/chat/completions',
+    name: 'o4-mini-2025-04-16',
+    maxContextWindow: 128_000,
+    maxOutputTokens: 16_384,
+    requestTimeout: 40_000,
+    apiKey: process.env.OPENAI_API_KEY,
+    apiUrl: 'https://api.openai.com/',
+    systemPrompt,
+  };
+
+  // Caution!: $10-40/1M tokens
+  // cutoff: 05/2024
+  // supports image inputs
+  _models.reasoningNoImage = {
+    endpoint: 'v1/chat/completions',
+    name: 'o3-2025-04-16',
+    maxContextWindow: 200_000,
+    maxOutputTokens: 100_000,
+    requestTimeout: 120_000,
+    apiKey: process.env.OPENAI_API_KEY,
+    apiUrl: 'https://api.openai.com/',
+    systemPrompt,
+  };
+
+  // Full matrix with explicit names (no aliases)
+  _models.fastGoodCheapMulti = _models.fastGoodMulti; // Default system model
+  _models.fastGoodCheap = _models.fastGoodMulti;
+  _models.fastMulti = _models.fastGoodMulti;
+  _models.fast = _models.fastGoodMulti;
+  _models.fastGood = _models.fastGoodMulti;
+  _models.fastReasoningMulti = _models.fastCheapReasoningMulti;
+  _models.fastReasoning = _models.fastCheapReasoningMulti; 
+
+  _models.fastCheapMulti = _models.fastCheapMulti;
+  _models.fastCheap = _models.fastCheapMulti;
+  _models.fastCheapReasoning = _models.fastCheapReasoningMulti;
+  
+  _models.cheapMulti = _models.fastCheapMulti;
+  _models.cheap = _models.fastCheapMulti;
+  _models.cheapGoodMulti = _models.fastGoodMulti;
+  _models.cheapGood = _models.fastGoodMulti;
+  _models.cheapReasoningMulti = _models.fastCheapReasoningMulti;
+  _models.cheapReasoning = _models.fastCheapReasoningMulti;
+
+  _models.goodMulti = _models.goodMulti; // Caution: Moderate cost
+  _models.good = _models.goodMulti; // Caution: Moderate cost
+
+  _models.reasoningMulti = _models.fastCheapReasoningMulti; // Caution: Moderate cost
+  _models.reasoning = _models.reasoningNoImage; // Caution: High cost
 }
 
 if (process.env.OPENWEBUI_API_URL && process.env.OPENWEBUI_API_KEY) {
-  _models.privateBase = {
-    name: 'cogito:latest',
+  // cutoff: 03/2024
+  // Supports image inputs
+  _models.privacy = {
+    name: 'gemma3:latest', // same as gemma3:4b
     endpoint: 'api/chat/completions',
-    maxTokens: 4096,
-    requestTimeout: 120000,
+    maxContextWindow: 128_000,
+    maxOutputTokens: 8_192,
+    requestTimeout: 120_000,
     apiUrl: process.env.OPENWEBUI_API_URL.endsWith('/')
       ? process.env.OPENWEBUI_API_URL
       : `${process.env.OPENWEBUI_API_URL}/`,
     apiKey: process.env.OPENWEBUI_API_KEY,
-    systemPrompt: `You are a helpful AI assistant powered by Llama 3. 
-                  You aim to be direct, accurate, and helpful.
-                  If you're not sure about something, say so.`,
+    systemPrompt,
     modelOptions: {
       stop: ['</s>'],
     },

--- a/src/lib/chatgpt/index.js
+++ b/src/lib/chatgpt/index.js
@@ -57,9 +57,19 @@ export const run = async (prompt, options = {}) => {
     shapeOutput = shapeOutputDefault,
   } = options;
 
-  const modelNameNegotiated = modelOptions.negotiate
-    ? modelService.negotiateModel(modelOptions.modelName, modelOptions.negotiate)
-    : modelOptions.modelName;
+  // Apply global overrides to model options
+  const modelOptionsWithOverrides = modelService.applyGlobalOverrides(modelOptions);
+
+  // Check if negotiation was applied via global override
+  const negotiationFromGlobalOverride = modelService.getGlobalOverride('negotiate');
+
+  const modelNameNegotiated = modelOptionsWithOverrides.negotiate
+    ? modelService.negotiateModel(
+        // If negotiation came from global override, don't use preferred model
+        negotiationFromGlobalOverride ? null : modelOptionsWithOverrides.modelName,
+        modelOptionsWithOverrides.negotiate
+      )
+    : modelOptionsWithOverrides.modelName;
 
   const modelFound = modelService.getModel(modelNameNegotiated);
 
@@ -69,7 +79,7 @@ export const run = async (prompt, options = {}) => {
 
   const requestConfig = modelService.getRequestConfig({
     prompt,
-    ...modelOptions,
+    ...modelOptionsWithOverrides,
     modelName: modelNameNegotiated,
   });
 

--- a/src/lib/functional/index.js
+++ b/src/lib/functional/index.js
@@ -1,0 +1,28 @@
+export const hook = (list, f, returnVal) => {
+  list.push(f);
+  return returnVal;
+};
+
+export const hookOnce = (list, f, returnVal) => {
+  if (list.includes(f)) return returnVal;
+  list.push(f);
+  return returnVal;
+};
+
+export const hookFn = (list, returnVal) => (f) => hook(list, f, returnVal);
+
+export const hookOnceFn = (list, returnVal) => (f) => hookOnce(list, f, returnVal);
+
+export const unhook = (list, f, returnVal) => {
+  const idx = list.indexOf(f);
+  if (idx === -1) return returnVal;
+  list.splice(idx, 1);
+  return returnVal;
+};
+
+export const unhookFn = (list, returnVal) => (f) => unhook(list, f, returnVal);
+
+export const unhookAll = (list, returnVal) => {
+  list.splice(0);
+  return returnVal;
+};

--- a/src/services/llm-model/global-overrides.spec.js
+++ b/src/services/llm-model/global-overrides.spec.js
@@ -1,0 +1,432 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import fetch from 'node-fetch';
+import modelService from './index.js';
+import Model from './model.js';
+
+import { run as chatgptRun } from '../../lib/chatgpt/index.js';
+
+// Mock node-fetch before importing chatgpt
+vi.mock('node-fetch', () => ({
+  default: vi.fn(),
+}));
+
+// Mock Redis
+vi.mock('../../services/redis/index.js', () => ({
+  getClient: vi.fn().mockResolvedValue({
+    get: vi.fn().mockResolvedValue(null),
+    setex: vi.fn().mockResolvedValue('OK'),
+  }),
+}));
+
+// Mock the prompt cache to avoid Redis dependencies
+vi.mock('../../lib/prompt-cache/index.js', () => ({
+  get: vi.fn().mockResolvedValue({ result: null }),
+  set: vi.fn().mockResolvedValue('OK'),
+}));
+
+// Helper tokenizer
+const tokenizer = (t) => t.split(' ');
+
+describe('Global Override System', () => {
+  beforeEach(() => {
+    // Reset models and overrides before each test
+    modelService.models = {};
+    modelService.clearGlobalOverride(); // Clear all overrides
+    modelService.bestPublicModelKey = 'fastGood';
+
+    // Setup basic models for testing
+    modelService.models = {
+      fastGood: new Model({
+        name: 'gpt-4-fast-good',
+        maxContextWindow: 128000,
+        maxOutputTokens: 16384,
+        requestTimeout: 1000,
+        apiUrl: 'https://api.openai.com',
+        apiKey: 'test-key',
+        endpoint: '/v1/chat/completions',
+        tokenizer,
+      }),
+      fastCheap: new Model({
+        name: 'gpt-4-fast-cheap',
+        maxContextWindow: 128000,
+        maxOutputTokens: 8192,
+        requestTimeout: 1000,
+        apiUrl: 'https://api.openai.com',
+        apiKey: 'test-key',
+        endpoint: '/v1/chat/completions',
+        tokenizer,
+      }),
+      fastCheapReasoning: new Model({
+        name: 'gpt-4-fast-cheap-reasoning',
+        maxContextWindow: 200000,
+        maxOutputTokens: 50000,
+        requestTimeout: 3000,
+        apiUrl: 'https://api.openai.com',
+        apiKey: 'reasoning-key',
+        endpoint: '/v1/chat/completions',
+        tokenizer,
+      }),
+      customModel: new Model({
+        name: 'custom-model-name',
+        maxContextWindow: 64000,
+        maxOutputTokens: 8192,
+        requestTimeout: 2000,
+        apiUrl: 'https://custom.api.com',
+        apiKey: 'custom-key',
+        endpoint: '/v1/completions',
+        tokenizer,
+      }),
+      expensiveReasoning: new Model({
+        name: 'gpt-4-reasoning',
+        maxContextWindow: 200000,
+        maxOutputTokens: 100000,
+        requestTimeout: 5000,
+        apiUrl: 'https://api.openai.com',
+        apiKey: 'reasoning-key',
+        endpoint: '/v1/chat/completions',
+        tokenizer,
+      }),
+      fastReasoning: new Model({
+        name: 'gpt-4-fast-reasoning',
+        maxContextWindow: 200000,
+        maxOutputTokens: 50000,
+        requestTimeout: 3000,
+        apiUrl: 'https://api.openai.com',
+        apiKey: 'reasoning-key',
+        endpoint: '/v1/chat/completions',
+        tokenizer,
+      }),
+    };
+
+    // Reset and setup fetch mock for each test
+    vi.clearAllMocks();
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: 'Test response' } }],
+        }),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    modelService.clearGlobalOverride(); // Clean up after each test
+  });
+
+  describe('Global Override Management', () => {
+    it('should set and get global overrides', () => {
+      modelService.setGlobalOverride('modelName', 'customModel');
+      modelService.setGlobalOverride('temperature', 0.8);
+
+      expect(modelService.getGlobalOverride('modelName')).toBe('customModel');
+      expect(modelService.getGlobalOverride('temperature')).toBe(0.8);
+      expect(modelService.getGlobalOverride('maxTokens')).toBe(null);
+    });
+
+    it('should get all global overrides', () => {
+      modelService.setGlobalOverride('modelName', 'customModel');
+      modelService.setGlobalOverride('temperature', 0.8);
+
+      const allOverrides = modelService.getAllGlobalOverrides();
+      expect(allOverrides.modelName).toBe('customModel');
+      expect(allOverrides.temperature).toBe(0.8);
+      expect(allOverrides.maxTokens).toBe(null);
+    });
+
+    it('should clear specific global overrides', () => {
+      modelService.setGlobalOverride('modelName', 'customModel');
+      modelService.setGlobalOverride('temperature', 0.8);
+
+      modelService.clearGlobalOverride('modelName');
+
+      expect(modelService.getGlobalOverride('modelName')).toBe(null);
+      expect(modelService.getGlobalOverride('temperature')).toBe(0.8);
+    });
+
+    it('should clear all global overrides', () => {
+      modelService.setGlobalOverride('modelName', 'customModel');
+      modelService.setGlobalOverride('temperature', 0.8);
+
+      modelService.clearGlobalOverride();
+
+      expect(modelService.getGlobalOverride('modelName')).toBe(null);
+      expect(modelService.getGlobalOverride('temperature')).toBe(null);
+    });
+
+    it('should throw error for invalid override keys', () => {
+      expect(() => {
+        modelService.setGlobalOverride('invalidKey', 'value');
+      }).toThrow('Invalid override key: invalidKey');
+
+      expect(() => {
+        modelService.clearGlobalOverride('invalidKey');
+      }).toThrow('Invalid override key: invalidKey');
+    });
+  });
+
+  describe('Model Name Override', () => {
+    it('should override model selection globally', async () => {
+      // Set global model override
+      modelService.setGlobalOverride('modelName', 'customModel');
+
+      const result = await chatgptRun('Test prompt', {
+        modelOptions: {
+          modelName: 'fastGood', // This should be overridden
+        },
+      });
+
+      expect(result).toBe('Test response');
+      expect(fetch).toHaveBeenCalledWith(
+        'https://custom.api.com/v1/completions',
+        expect.objectContaining({
+          headers: {
+            Authorization: 'Bearer custom-key',
+            'Content-Type': 'application/json',
+          },
+          body: expect.stringContaining('"model":"custom-model-name"'),
+        })
+      );
+    });
+
+    it('should override even when no modelOptions provided', async () => {
+      modelService.setGlobalOverride('modelName', 'expensiveReasoning');
+
+      const result = await chatgptRun('Test prompt');
+
+      expect(result).toBe('Test response');
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/chat/completions',
+        expect.objectContaining({
+          headers: {
+            Authorization: 'Bearer reasoning-key',
+            'Content-Type': 'application/json',
+          },
+          body: expect.stringContaining('"model":"gpt-4-reasoning"'),
+        })
+      );
+    });
+  });
+
+  describe('Negotiation Override', () => {
+    it('should override negotiation options globally', async () => {
+      modelService.setGlobalOverride('negotiate', { reasoning: true });
+
+      const result = await chatgptRun('Test prompt', {
+        modelOptions: {
+          modelName: 'fastGood',
+          negotiate: { fast: true, cheap: true }, // This should be overridden
+        },
+      });
+
+      expect(result).toBe('Test response');
+      // Should negotiate to reasoning model instead of fast+cheap
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/chat/completions',
+        expect.objectContaining({
+          body: expect.stringContaining('"model":"gpt-4-fast-cheap-reasoning"'),
+        })
+      );
+    });
+
+    it('should apply negotiation when none provided in options', async () => {
+      modelService.setGlobalOverride('negotiate', { fast: true, cheap: true });
+
+      const result = await chatgptRun('Test prompt', {
+        modelOptions: {
+          modelName: 'expensiveReasoning', // Should be overridden by negotiation
+        },
+      });
+
+      expect(result).toBe('Test response');
+      // Should negotiate instead of using explicit model
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/chat/completions',
+        expect.objectContaining({
+          body: expect.stringContaining('"model":"gpt-4-fast-cheap"'),
+        })
+      );
+    });
+  });
+
+  describe('Parameter Overrides', () => {
+    it('should override temperature globally', async () => {
+      modelService.setGlobalOverride('temperature', 0.9);
+
+      const result = await chatgptRun('Test prompt', {
+        modelOptions: {
+          modelName: 'fastGood',
+          temperature: 0.1, // This should be overridden
+        },
+      });
+
+      expect(result).toBe('Test response');
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/chat/completions',
+        expect.objectContaining({
+          body: expect.stringContaining('"temperature":0.9'),
+        })
+      );
+    });
+
+    it('should override multiple parameters', async () => {
+      modelService.setGlobalOverride('temperature', 0.8);
+      modelService.setGlobalOverride('maxTokens', 1500);
+      modelService.setGlobalOverride('topP', 0.95);
+
+      const result = await chatgptRun('Test prompt', {
+        modelOptions: {
+          modelName: 'fastGood',
+          temperature: 0.1,
+          maxTokens: 500,
+          topP: 0.5,
+        },
+      });
+
+      expect(result).toBe('Test response');
+
+      const requestBody = JSON.parse(fetch.mock.calls[0][1].body);
+      expect(requestBody.temperature).toBe(0.8);
+      expect(requestBody.max_tokens).toBe(1500);
+      expect(requestBody.top_p).toBe(0.95);
+    });
+
+    it('should preserve non-overridden parameters', async () => {
+      modelService.setGlobalOverride('temperature', 0.8);
+
+      const result = await chatgptRun('Test prompt', {
+        modelOptions: {
+          modelName: 'fastGood',
+          temperature: 0.1,
+          maxTokens: 2000,
+          topP: 0.7,
+        },
+      });
+
+      expect(result).toBe('Test response');
+
+      const requestBody = JSON.parse(fetch.mock.calls[0][1].body);
+      expect(requestBody.temperature).toBe(0.8); // Overridden
+      expect(requestBody.max_tokens).toBe(2000); // Preserved
+      expect(requestBody.top_p).toBe(0.7); // Preserved
+    });
+  });
+
+  describe('Complex Override Scenarios', () => {
+    it('should combine model and parameter overrides', async () => {
+      modelService.setGlobalOverride('modelName', 'customModel');
+      modelService.setGlobalOverride('temperature', 0.9);
+
+      const result = await chatgptRun('Test prompt', {
+        modelOptions: {
+          modelName: 'fastGood',
+          temperature: 0.1,
+          maxTokens: 1000,
+        },
+      });
+
+      expect(result).toBe('Test response');
+      expect(fetch).toHaveBeenCalledWith(
+        'https://custom.api.com/v1/completions',
+        expect.objectContaining({
+          headers: {
+            Authorization: 'Bearer custom-key',
+            'Content-Type': 'application/json',
+          },
+          body: expect.stringContaining('"temperature":0.9'),
+        })
+      );
+
+      const requestBody = JSON.parse(fetch.mock.calls[0][1].body);
+      expect(requestBody.model).toBe('custom-model-name');
+      expect(requestBody.max_tokens).toBe(1000); // Preserved
+    });
+
+    it('should handle override precedence correctly', async () => {
+      // Set both model name and negotiation overrides
+      modelService.setGlobalOverride('modelName', 'customModel');
+      modelService.setGlobalOverride('negotiate', { reasoning: true });
+
+      const result = await chatgptRun('Test prompt', {
+        modelOptions: {
+          modelName: 'fastGood',
+        },
+      });
+
+      expect(result).toBe('Test response');
+      // Negotiation should take precedence and override the model name
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/chat/completions',
+        expect.objectContaining({
+          body: expect.stringContaining('"model":"gpt-4-fast-cheap-reasoning"'),
+        })
+      );
+    });
+
+    it('should work with empty modelOptions', async () => {
+      modelService.setGlobalOverride('modelName', 'customModel');
+      modelService.setGlobalOverride('temperature', 0.7);
+
+      const result = await chatgptRun('Test prompt');
+
+      expect(result).toBe('Test response');
+      expect(fetch).toHaveBeenCalledWith(
+        'https://custom.api.com/v1/completions',
+        expect.objectContaining({
+          headers: {
+            Authorization: 'Bearer custom-key',
+            'Content-Type': 'application/json',
+          },
+          body: expect.stringContaining('"temperature":0.7'),
+        })
+      );
+    });
+  });
+
+  describe('Override Isolation', () => {
+    it('should not affect subsequent calls after clearing overrides', async () => {
+      // Set override and make a call
+      modelService.setGlobalOverride('modelName', 'customModel');
+
+      await chatgptRun('Test prompt 1');
+      expect(fetch).toHaveBeenCalledWith(
+        'https://custom.api.com/v1/completions',
+        expect.anything()
+      );
+
+      // Clear override and make another call
+      modelService.clearGlobalOverride('modelName');
+      fetch.mockClear();
+
+      await chatgptRun('Test prompt 2');
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/chat/completions',
+        expect.anything()
+      );
+    });
+
+    it('should apply overrides consistently across multiple calls', async () => {
+      modelService.setGlobalOverride('temperature', 0.8);
+
+      // First call
+      await chatgptRun('Test prompt 1', {
+        modelOptions: { modelName: 'fastGood', temperature: 0.1 },
+      });
+
+      // Second call
+      await chatgptRun('Test prompt 2', {
+        modelOptions: { modelName: 'customModel', temperature: 0.2 },
+      });
+
+      // Both calls should have temperature overridden to 0.8
+      expect(fetch).toHaveBeenCalledTimes(2);
+
+      const firstCall = JSON.parse(fetch.mock.calls[0][1].body);
+      const secondCall = JSON.parse(fetch.mock.calls[1][1].body);
+
+      expect(firstCall.temperature).toBe(0.8);
+      expect(secondCall.temperature).toBe(0.8);
+    });
+  });
+});

--- a/src/services/llm-model/index.js
+++ b/src/services/llm-model/index.js
@@ -9,6 +9,33 @@ import {
   topP as topPConfig,
 } from '../../constants/models.js';
 
+// Prioritized list of models (best to worst, excluding privacy/reasoning which are never auto-invoked)
+const prioritizedModels = [
+  'fastGoodCheap',
+  'fastGoodCheapMulti',
+  'fastGood',
+  'fastGoodMulti',
+  'goodCheap',
+  'goodCheapMulti',
+  'good',
+  'goodMulti',
+  'fastCheap',
+  'fastCheapMulti',
+  'fast',
+  'fastMulti',
+  'cheap',
+  'cheapMulti',
+  'multi',
+  'fastCheapReasoning',
+  'fastCheapReasoningMulti',
+  'fastReasoning',
+  'fastReasoningMulti',
+  'cheapReasoning',
+  'cheapReasoningMulti',
+  'reasoning',
+  'reasoningMulti',
+];
+
 class ModelService {
   constructor() {
     this.models = {};
@@ -24,24 +51,71 @@ class ModelService {
       {}
     );
 
-    if (Object.keys(this.models).length === 0) {
-      this.models.fastGood = new Model({
-        name: 'test-model',
-        maxTokens: 1000,
-        requestTimeout: 1000,
-        key: 'fastGood',
-        tokenizer: tokenizer.encode,
+    // Always default to fastGood for public model
+    this.bestPublicModelKey = 'fastGood';
+
+    // Global overrides
+    this.globalOverrides = {
+      modelName: null, // Force specific model
+      negotiate: null, // Force specific negotiation options
+      temperature: null, // Force specific temperature
+      maxTokens: null, // Force specific max tokens
+      topP: null, // Force specific top_p
+      frequencyPenalty: null, // Force specific frequency penalty
+      presencePenalty: null, // Force specific presence penalty
+    };
+  }
+
+  // Global override management
+  setGlobalOverride(key, value) {
+    if (!(key in this.globalOverrides)) {
+      throw new Error(
+        `Invalid override key: ${key}. Valid keys are: ${Object.keys(this.globalOverrides).join(
+          ', '
+        )}`
+      );
+    }
+    this.globalOverrides[key] = value;
+  }
+
+  clearGlobalOverride(key) {
+    if (key) {
+      if (!(key in this.globalOverrides)) {
+        throw new Error(
+          `Invalid override key: ${key}. Valid keys are: ${Object.keys(this.globalOverrides).join(
+            ', '
+          )}`
+        );
+      }
+      this.globalOverrides[key] = null;
+    } else {
+      // Clear all overrides
+      Object.keys(this.globalOverrides).forEach((k) => {
+        this.globalOverrides[k] = null;
       });
     }
+  }
 
-    // Default to reasoning model when available
-    this.bestPublicModelKey = this.models.reasoning ? 'reasoning' : 'fastGood';
+  getGlobalOverride(key) {
+    return this.globalOverrides[key];
+  }
 
-    if (process.env.TEST === 'true') {
-      this.bestPublicModelKey = this.models.reasoning ? 'reasoning' : 'fastGood';
-    }
+  getAllGlobalOverrides() {
+    return { ...this.globalOverrides };
+  }
 
-    this.bestPrivateModelKey = this.models.privacy ? 'privacy' : this.bestPublicModelKey;
+  // Apply global overrides to model options
+  applyGlobalOverrides(modelOptions) {
+    const result = { ...modelOptions };
+
+    // Apply each override if it's set (not null)
+    Object.entries(this.globalOverrides).forEach(([key, value]) => {
+      if (value !== null) {
+        result[key] = value;
+      }
+    });
+
+    return result;
   }
 
   getBestPublicModel() {
@@ -49,7 +123,12 @@ class ModelService {
   }
 
   getBestPrivateModel() {
-    return this.models[this.bestPrivateModelKey];
+    if (!this.models.privacy) {
+      throw new Error(
+        'No privacy model configured. Configure a privacy model or use a public model instead.'
+      );
+    }
+    return this.models.privacy;
   }
 
   updateBestPublicModel(name) {
@@ -69,25 +148,89 @@ class ModelService {
   }
 
   negotiateModel(preferred, negotiation = {}) {
-    const { privacy, reasoning, fast, cheap } = negotiation;
+    const { privacy, reasoning, fast, cheap, good, multi } = negotiation;
 
-    if (privacy && this.models.privacy) {
+    // Privacy models take absolute priority
+    if (privacy) {
+      if (!this.models.privacy) {
+        return undefined;
+      }
       return 'privacy';
     }
 
-    if (reasoning && this.models.reasoning) {
-      return 'reasoning';
+    // Helper function to check if a model matches all requirements
+    const matchesRequirements = (modelKey) => {
+      if (!this.models[modelKey]) {
+        return false;
+      }
+
+      const lowerModelKey = modelKey.toLowerCase();
+
+      // Check each requirement - support both positive and negative (false) requirements
+      // Only check requirements that are explicitly specified (not undefined)
+      if (fast === true && !/fast/i.test(lowerModelKey)) {
+        return false;
+      }
+      if (fast === false && /fast/i.test(lowerModelKey)) {
+        return false;
+      }
+      if (cheap === true && !/cheap/i.test(lowerModelKey)) {
+        return false;
+      }
+      if (cheap === false && /cheap/i.test(lowerModelKey)) {
+        return false;
+      }
+      if (good === true && !/good/i.test(lowerModelKey)) {
+        return false;
+      }
+      if (good === false && /good/i.test(lowerModelKey)) {
+        return false;
+      }
+      if (reasoning === true && !/reasoning/i.test(lowerModelKey)) {
+        return false;
+      }
+      if (reasoning === false && /reasoning/i.test(lowerModelKey)) {
+        return false;
+      }
+      if (multi === true && !/multi/i.test(lowerModelKey)) {
+        return false;
+      }
+      if (multi === false && /multi/i.test(lowerModelKey)) {
+        return false;
+      }
+      return true;
+    };
+
+    // Check if any specific requirements are given
+    const hasSpecificRequirements =
+      fast !== undefined ||
+      cheap !== undefined ||
+      good !== undefined ||
+      reasoning !== undefined ||
+      multi !== undefined;
+
+    // If no specific requirements are given, return preferred model if available
+    if (!hasSpecificRequirements) {
+      if (preferred && this.models[preferred]) {
+        return preferred;
+      }
+      return this.bestPublicModelKey;
     }
 
-    if (fast && this.models.fastGood) {
-      return 'fastGood';
+    // Find the first model that matches all requirements
+    for (const modelKey of prioritizedModels) {
+      if (matchesRequirements(modelKey)) {
+        return modelKey;
+      }
     }
 
-    if (cheap && this.models.fastCheap) {
-      return 'fastCheap';
+    // Check if specific critical requirements were requested but couldn't be satisfied
+    if (reasoning === true) {
+      return undefined;
     }
 
-    return preferred || this.bestPublicModelKey;
+    // If specific requirements were given but couldn't be satisfied, return undefined
+    return undefined;
   }
 
   getRequestParameters(options = {}) {
@@ -101,7 +244,10 @@ class ModelService {
 
     let maxTokensFound = maxTokens;
     if (!maxTokens) {
-      maxTokensFound = modelFound.maxTokens - modelFound.toTokens(prompt);
+      const promptTokens = modelFound.toTokens(prompt).length;
+      const availableTokens = modelFound.maxContextWindow - promptTokens;
+      // Cap to the model's maximum output tokens
+      maxTokensFound = Math.min(availableTokens, modelFound.maxOutputTokens);
     }
 
     return {

--- a/src/services/llm-model/model.js
+++ b/src/services/llm-model/model.js
@@ -9,8 +9,8 @@ export default class Model {
 
   budgetTokens(text, { completionMax = Infinity } = {}) {
     const prompt = this.toTokens(text).length;
-    const total = this.maxTokens;
-    const completion = Math.min(total - prompt, completionMax);
+    const total = this.maxContextWindow;
+    const completion = Math.min(Math.min(total - prompt, this.maxOutputTokens), completionMax);
 
     return {
       completion,

--- a/src/services/llm-model/negotiate.spec.js
+++ b/src/services/llm-model/negotiate.spec.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import modelService from './index.js';
+import Model from './model.js';
+
+// helper tokenizer
+const tokenizer = (t) => t.split(' ');
+
+describe('Model negotiation', () => {
+  it('prefers privacy model when requested', () => {
+    modelService.models = {
+      privacy: new Model({
+        name: 'p',
+        maxTokens: 10,
+        requestTimeout: 1,
+        tokenizer,
+      }),
+      fastGood: new Model({
+        name: 'fg',
+        maxTokens: 10,
+        requestTimeout: 1,
+        tokenizer,
+      }),
+    };
+    modelService.bestPublicModelKey = 'fastGood';
+    modelService.bestPrivateModelKey = 'privacy';
+
+    const key = modelService.negotiateModel('fastGood', { privacy: true });
+    expect(key).toBe('privacy');
+  });
+
+  it('falls back to preferred when no flags set', () => {
+    modelService.models.fastGood = new Model({
+      name: 'fg',
+      maxTokens: 10,
+      requestTimeout: 1,
+      tokenizer,
+    });
+    const key = modelService.negotiateModel('fastGood', {});
+    expect(key).toBe('fastGood');
+  });
+});

--- a/src/services/llm-model/negotiate.spec.js
+++ b/src/services/llm-model/negotiate.spec.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach } from 'vitest';
 import modelService from './index.js';
 import Model from './model.js';
 
@@ -6,36 +6,442 @@ import Model from './model.js';
 const tokenizer = (t) => t.split(' ');
 
 describe('Model negotiation', () => {
-  it('prefers privacy model when requested', () => {
-    modelService.models = {
-      privacy: new Model({
-        name: 'p',
-        maxTokens: 10,
-        requestTimeout: 1,
-        tokenizer,
-      }),
-      fastGood: new Model({
-        name: 'fg',
-        maxTokens: 10,
-        requestTimeout: 1,
-        tokenizer,
-      }),
-    };
+  beforeEach(() => {
+    // Reset models before each test
+    modelService.models = {};
     modelService.bestPublicModelKey = 'fastGood';
-    modelService.bestPrivateModelKey = 'privacy';
-
-    const key = modelService.negotiateModel('fastGood', { privacy: true });
-    expect(key).toBe('privacy');
   });
 
-  it('falls back to preferred when no flags set', () => {
-    modelService.models.fastGood = new Model({
-      name: 'fg',
-      maxTokens: 10,
-      requestTimeout: 1,
-      tokenizer,
+  describe('Privacy models', () => {
+    it('prefers privacy model when requested and available', () => {
+      modelService.models = {
+        privacy: new Model({
+          name: 'privacy-model',
+          maxContextWindow: 128000,
+          maxOutputTokens: 8192,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fastGood: new Model({
+          name: 'fast-good-model',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+      };
+
+      const key = modelService.negotiateModel('fastGood', { privacy: true });
+      expect(key).toBe('privacy');
     });
-    const key = modelService.negotiateModel('fastGood', {});
-    expect(key).toBe('fastGood');
+
+    it('throws error when privacy requested but not configured', () => {
+      modelService.models = {
+        fastGood: new Model({
+          name: 'fast-good-model',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+      };
+
+      expect(modelService.negotiateModel('fastGood', { privacy: true })).toBe(undefined);
+    });
+  });
+
+  describe('Exact model key matching', () => {
+    beforeEach(() => {
+      modelService.models = {
+        fastGood: new Model({
+          name: 'fast-good',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fastCheap: new Model({
+          name: 'fast-cheap',
+          maxContextWindow: 128000,
+          maxOutputTokens: 8192,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fastReasoning: new Model({
+          name: 'fast-reasoning',
+          maxContextWindow: 200000,
+          maxOutputTokens: 100000,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fastCheapReasoning: new Model({
+          name: 'fast-cheap-reasoning',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fastGoodMulti: new Model({
+          name: 'fast-good-multi',
+          maxContextWindow: 1000000,
+          maxOutputTokens: 32768,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fastCheapReasoningMulti: new Model({
+          name: 'fast-cheap-reasoning-multi',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        good: new Model({
+          name: 'good',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        reasoning: new Model({
+          name: 'reasoning',
+          maxContextWindow: 200000,
+          maxOutputTokens: 100000,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fast: new Model({
+          name: 'fast',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        cheap: new Model({
+          name: 'cheap',
+          maxContextWindow: 128000,
+          maxOutputTokens: 8192,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+      };
+    });
+
+    it('returns highest priority match for fast + cheap', () => {
+      // Should find fastCheap since it has both fast and cheap
+      const key = modelService.negotiateModel(null, { fast: true, cheap: true });
+      expect(key).toBe('fastCheap'); // fastCheap matches both requirements
+    });
+
+    it('returns highest priority match for fast + reasoning', () => {
+      // Should find fastReasoning since it has both fast and reasoning
+      const key = modelService.negotiateModel(null, { fast: true, reasoning: true });
+      expect(key).toBe('fastCheapReasoning'); // fastReasoning matches both requirements
+    });
+
+    it('returns exact match when it exists and has high priority', () => {
+      const key = modelService.negotiateModel(null, { fast: true, cheap: true, reasoning: true });
+      expect(key).toBe('fastCheapReasoning'); // Exact match exists
+    });
+
+    it('returns exact match for fast + good + multi', () => {
+      const key = modelService.negotiateModel(null, { fast: true, good: true, multi: true });
+      expect(key).toBe('fastGoodMulti'); // Exact match exists
+    });
+
+    it('returns exact match for fast + cheap + reasoning + multi', () => {
+      const key = modelService.negotiateModel(null, {
+        fast: true,
+        cheap: true,
+        reasoning: true,
+        multi: true,
+      });
+      expect(key).toBe('fastCheapReasoningMulti'); // Exact match exists
+    });
+  });
+
+  describe('Fallback logic', () => {
+    beforeEach(() => {
+      modelService.models = {
+        fastGoodCheap: new Model({
+          name: 'fast-good-cheap',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fastGood: new Model({
+          name: 'fast-good',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fastCheap: new Model({
+          name: 'fast-cheap',
+          maxContextWindow: 128000,
+          maxOutputTokens: 8192,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fastReasoning: new Model({
+          name: 'fast-reasoning',
+          maxContextWindow: 200000,
+          maxOutputTokens: 100000,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        good: new Model({
+          name: 'good',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        reasoning: new Model({
+          name: 'reasoning',
+          maxContextWindow: 200000,
+          maxOutputTokens: 100000,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fast: new Model({
+          name: 'fast',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        cheap: new Model({
+          name: 'cheap',
+          maxContextWindow: 128000,
+          maxOutputTokens: 8192,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+      };
+    });
+
+    it('finds exact match when available', () => {
+      const key = modelService.negotiateModel(null, { fast: true, good: true });
+      expect(key).toBe('fastGoodCheap');
+    });
+
+    it('requires all specified features to match', () => {
+      // Request multi but no multi models exist - should return undefined
+      expect(modelService.negotiateModel(null, { fast: true, multi: true })).toBe(undefined);
+    });
+
+    it('picks higher priority model when multiple match', () => {
+      // Both fastGoodCheap, fastGood and good match { good: true }, should pick fastGoodCheap (highest priority)
+      const key = modelService.negotiateModel(null, { good: true });
+      expect(key).toBe('fastGoodCheap');
+    });
+
+    it('respects all requirements strictly', () => {
+      // Request fast + cheap + reasoning - no exact match available, should return undefined since reasoning is requested
+      expect(modelService.negotiateModel(null, { fast: true, cheap: true, reasoning: true })).toBe(
+        undefined
+      );
+    });
+
+    it('works with single requirements', () => {
+      const key = modelService.negotiateModel(null, { reasoning: true });
+      expect(key).toBe('fastReasoning');
+    });
+
+    it('works with multi requirement when available', () => {
+      modelService.models.fastGoodMulti = new Model({
+        name: 'fast-good-multi',
+        maxContextWindow: 1000000,
+        maxOutputTokens: 32768,
+        requestTimeout: 1000,
+        tokenizer,
+      });
+
+      const key = modelService.negotiateModel(null, { fast: true, good: true, multi: true });
+      expect(key).toBe('fastGoodMulti');
+    });
+
+    it('falls back to best public model when no matches found', () => {
+      // Request something that doesn't exist with reasoning - should return undefined
+      expect(
+        modelService.negotiateModel(null, {
+          fast: true,
+          cheap: true,
+          good: true,
+          reasoning: true,
+          multi: true,
+        })
+      ).toBe(undefined);
+    });
+
+    it('prioritizes better combinations over individual features', () => {
+      // Both fast and fastGoodCheap match { fast: true }, should pick fastGoodCheap
+      const key = modelService.negotiateModel(null, { fast: true });
+      expect(key).toBe('fastGoodCheap');
+    });
+  });
+
+  describe('Preferred model handling', () => {
+    beforeEach(() => {
+      modelService.models = {
+        fastGood: new Model({
+          name: 'fast-good',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        customModel: new Model({
+          name: 'custom',
+          maxContextWindow: 64000,
+          maxOutputTokens: 8192,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+      };
+    });
+
+    it('returns preferred model when available and no privacy requested', () => {
+      const key = modelService.negotiateModel('customModel', { fast: true });
+      expect(key).toBe('fastGood');
+    });
+
+    it('ignores preferred model when privacy is requested', () => {
+      modelService.models.privacy = new Model({
+        name: 'privacy',
+        maxContextWindow: 128000,
+        maxOutputTokens: 8192,
+        requestTimeout: 1000,
+        tokenizer,
+      });
+
+      const key = modelService.negotiateModel('customModel', { privacy: true });
+      expect(key).toBe('privacy');
+    });
+
+    it('falls back to negotiation when preferred model does not exist', () => {
+      const key = modelService.negotiateModel('nonExistentModel', { fast: true });
+      expect(key).toBe('fastGood');
+    });
+  });
+
+  describe('Edge cases', () => {
+    beforeEach(() => {
+      modelService.models = {
+        fastGood: new Model({
+          name: 'fast-good',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+      };
+    });
+
+    it('handles empty negotiation object', () => {
+      const key = modelService.negotiateModel(null, {});
+      expect(key).toBe('fastGood');
+    });
+
+    it('handles undefined negotiation', () => {
+      const key = modelService.negotiateModel(null);
+      expect(key).toBe('fastGood');
+    });
+
+    it('handles single flag requests', () => {
+      const key = modelService.negotiateModel(null, { fast: true });
+      expect(key).toBe('fastGood');
+    });
+
+    it('prioritizes reasoning over good when both are requested', () => {
+      modelService.models.fastReasoning = new Model({
+        name: 'fast-reasoning',
+        maxContextWindow: 200000,
+        maxOutputTokens: 100000,
+        requestTimeout: 1000,
+        tokenizer,
+      });
+
+      // Request fast + reasoning + good but no model has all three - should return undefined
+      expect(modelService.negotiateModel(null, { fast: true, reasoning: true, good: true })).toBe(
+        undefined
+      );
+    });
+  });
+
+  describe('Property negation', () => {
+    beforeEach(() => {
+      modelService.models = {
+        fastGoodCheap: new Model({
+          name: 'fast-good-cheap',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fastGood: new Model({
+          name: 'fast-good',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        good: new Model({
+          name: 'good',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        fast: new Model({
+          name: 'fast',
+          maxContextWindow: 128000,
+          maxOutputTokens: 16384,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+        reasoning: new Model({
+          name: 'reasoning',
+          maxContextWindow: 200000,
+          maxOutputTokens: 100000,
+          requestTimeout: 1000,
+          tokenizer,
+        }),
+      };
+    });
+
+    it('excludes models with negated properties', () => {
+      // Request good but NOT fast - should pick 'good' over 'fastGood'
+      const key = modelService.negotiateModel(null, { good: true, fast: false });
+      expect(key).toBe('good');
+    });
+
+    it('excludes models with multiple negated properties', () => {
+      // Request good but NOT fast and NOT cheap - should pick 'good'
+      const key = modelService.negotiateModel(null, { good: true, fast: false, cheap: false });
+      expect(key).toBe('good');
+    });
+
+    it('works with only negated properties', () => {
+      // Request NOT fast - should pick 'good' (first non-fast model in priority)
+      const key = modelService.negotiateModel(null, { fast: false });
+      expect(key).toBe('good');
+    });
+
+    it('combines positive and negative requirements', () => {
+      // Request fast but NOT good - should pick 'fast' over 'fastGood'
+      // fastGoodCheap has both fast and good, so it's excluded by good: false
+      // fastGood has both fast and good, so it's excluded by good: false
+      // fast has fast but no good, so it matches
+      const key = modelService.negotiateModel(null, { fast: true, good: false });
+      expect(key).toBe('fast');
+    });
+
+    it('falls back when negation eliminates all matches', () => {
+      // Request NOT reasoning (all models are non-reasoning, so should pick first priority)
+      const key = modelService.negotiateModel(null, { good: false });
+      expect(key).toBe('fast');
+    });
   });
 });

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -7,11 +7,6 @@ dotenv.config();
 
 let redisClient;
 
-// Ensure environment variables are set for tests
-if (process.env.EXAMPLES === 'true') {
-  process.env.GPT_REASONING_ENABLED = 'true';
-}
-
 beforeEach(async () => {
   // Get a fresh Redis client for each test
   redisClient = await getRedis();

--- a/src/verblets/to-object/index.js
+++ b/src/verblets/to-object/index.js
@@ -79,7 +79,7 @@ export default async (text, schema) => {
     prompt = buildJsonPrompt(response, schema, errorDetails);
     response = await chatGPT(prompt, {
       modelOptions: {
-        modelName: 'publicBase',
+        modelName: 'fastGood',
       },
     });
     result = JSON.parse(stripResponse(response));
@@ -112,7 +112,7 @@ export default async (text, schema) => {
     prompt = buildJsonPrompt(response, schema, errorDetails);
     response = await chatGPT(prompt, {
       modelOptions: {
-        modelName: 'publicBase',
+        modelName: 'fastGood',
       },
     });
     result = JSON.parse(stripResponse(response));


### PR DESCRIPTION
## Summary
- drop `publicBase`, `publicReasoning` and `privateBase` aliases
- always create the `reasoning` model when an API key is provided
- simplify best model selection logic
- remove old GPT_REASONING env usage

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_6830bd6bcf208332bad448f5c310ff3b