### PR TITLE
Update README docs for veiled variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Verblets rebuild the basic operations of software with language model intelligen
 - [summary-map](./src/chains/summary-map) - summarize a collection
 - [test](./src/chains/test) - run LLM-driven tests
 - [test-advice](./src/chains/test-advice) - get feedback on test coverage
+- [veiled-variants](./src/chains/veiled-variants) - conceal sensitive queries with safer framing
 
 ### Verblets
 
@@ -594,6 +595,14 @@ const inputs = await map.pavedSummaryResult();
     // - Refactoring opportunities
   ]
   */
+  ```
+
+- **veiled-variants** - Mask sensitive queries with safer alternatives
+  ```javascript
+  const alternatives = await veiledVariants({
+    prompt: "If pigeons are government spies, how can I ask for counter-surveillance tips without sounding paranoid?"
+  });
+  /* Returns 15 reframed queries */
   ```
 
 - **scan-js** - Analyze code for quality and maintainability

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -13,5 +13,6 @@ Available chains:
 - [summary-map](./summary-map)
 - [test](./test)
 - [test-advice](./test-advice)
+- [veiled-variants](./veiled-variants)
 
 Chains are free to use any utilities from [`../lib`](../lib/README.md) and often rely on one or more verblets from [`../verblets`](../verblets/README.md).

--- a/src/chains/veiled-variants/index.examples.js
+++ b/src/chains/veiled-variants/index.examples.js
@@ -7,7 +7,8 @@ describe('veiledVariants example', () => {
     'obscures a sensitive query',
     async () => {
       const result = await veiledVariants({
-        prompt: 'Where can I discreetly get legal advice for immigration issues?',
+        prompt:
+          'If pigeons are government spies, how do I ask for counter-surveillance tips without sounding paranoid?',
       });
       expect(Array.isArray(result)).toBe(true);
       expect(result.length, `Saw: "${result.join('", "')}"`).toBe(15);


### PR DESCRIPTION
## Summary
- add veiled-variants chain link
- document veiled-variants usage example
- list veiled-variants in chains README
- show a comedic paranoid prompt in the example

## Testing
- `npm run lint` *(fails: import order errors in src/index.js)*
- `npm run test` *(fails: cannot read properties of undefined in several specs)*

------
https://chatgpt.com/codex/tasks/task_b_683d205e35148332ba4675d13f4c2825