### PR TITLE
Add privacy model options to scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "uuid": "^9.0.0",
     "vitest": "^3.1.3",
     "whisper-node": "^1.1.1",
-    "yargs": "^17.7.1"
+    "yargs": "^17.7.1",
+    "commander": "^11.0.0"
   },
   "devDependencies": {
     "@types/node": "^18.16.3",

--- a/scripts/generate-test/index.js
+++ b/scripts/generate-test/index.js
@@ -8,9 +8,35 @@ chatGPT,
   getRedis,
   SummaryMap
 } from '../../src/index.js';
+import modelService from '../../src/services/llm-model/index.js';
+import { Command } from 'commander';
 
-const modulePath = process.argv[2];
-const functionName = process.argv[3];
+const program = new Command();
+program
+  .argument('<modulePath>', 'Module to test')
+  .argument('[functionName]', 'Specific function to test')
+  .option('-p, --privacy', 'Use privacy model if configured')
+  .option('-m, --model <modelName>', 'Specify model name to use');
+
+program.parse(process.argv);
+
+const options = program.opts();
+const [modulePath, functionName] = program.args;
+
+if (options.privacy) {
+  try {
+    modelService.setGlobalOverride('modelName', 'privacy');
+  } catch (err) {
+    console.error(`Privacy model error: ${err.message}`);
+  }
+}
+if (options.model) {
+  try {
+    modelService.setGlobalOverride('modelName', options.model);
+  } catch (err) {
+    console.error(`Model override error: ${err.message}`);
+  }
+}
 
 if (!modulePath) {
   console.error('Please specify a module to test.');

--- a/scripts/runner/index.js
+++ b/scripts/runner/index.js
@@ -5,6 +5,32 @@ import chatGPT, {
   retry as run,
   schemas,
 } from '../../src/index.js';
+import modelService from '../../src/services/llm-model/index.js';
+import { Command } from 'commander';
+
+const program = new Command();
+program
+  .option('-p, --privacy', 'Use privacy model if configured')
+  .option('-m, --model <modelName>', 'Specify model name to use');
+
+program.parse(process.argv);
+
+const options = program.opts();
+
+if (options.privacy) {
+  try {
+    modelService.setGlobalOverride('modelName', 'privacy');
+  } catch (err) {
+    console.error(`Privacy model error: ${err.message}`);
+  }
+}
+if (options.model) {
+  try {
+    modelService.setGlobalOverride('modelName', options.model);
+  } catch (err) {
+    console.error(`Model override error: ${err.message}`);
+  }
+}
 
 await run(async () => {
   const results = await chatGPT('make a list of nintendo games with a schema that includes a title, year, and maybe a couple others of your choice', {


### PR DESCRIPTION
## Summary
- add commander CLI parsing to runner, generate-test, summarize-files and simple-editor
- add commander dependency
- allow privacy or custom model selection via CLI flags

## Testing
- `npm run lint` *(fails: 15 errors, 1 warning)*
- `npm run test` *(fails: 6 failed, 96 passed)*


------
https://chatgpt.com/codex/tasks/task_b_683d1fe3cc208332899d68fce9038197