### PR TITLE
Add llm-map utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Verblets rebuild the basic operations of software with language model intelligen
 - [number-with-units](./src/verblets/number-with-units) - parse numbers with units
 - [schema-org](./src/verblets/schema-org) - create schema.org objects
 - [to-object](./src/verblets/to-object) - convert descriptions to objects
+- [list-map](./src/verblets/list-map) - map lists with custom instructions
 
 ### Library Helpers
 
@@ -44,6 +45,7 @@ Verblets rebuild the basic operations of software with language model intelligen
 - [search-best-first](./src/lib/search-best-first) - best-first search
 - [search-js-files](./src/lib/search-js-files) - scan JavaScript sources
 - [shorten-text](./src/lib/shorten-text) - shorten text using a model
+- [bulkmap](./src/lib/bulk-map) - map long lists in retryable batches
 - [strip-numeric](./src/lib/strip-numeric) - remove non-digit characters
 - [strip-response](./src/lib/strip-response) - clean up model responses
 - [to-bool](./src/lib/to-bool) - parse text to boolean
@@ -484,6 +486,25 @@ const inputs = await map.pavedSummaryResult();
       ## Endpoints
       GET /users...DELETE /users/{id}"
   */
+  ```
+
+- **bulkmap** - Map over lists in retryable batches using `listMap`
+  ```javascript
+  import bulkMap from './src/lib/bulk-map/index.js';
+
+  const gadgets = [
+    'solar-powered flashlight',
+    'quantum laptop',
+    'smart refrigerator',
+    // ...more items
+  ];
+  const results = await bulkMap(
+    gadgets,
+    'Give each item a catchphrase worthy of a blockbuster commercial',
+    { chunkSize: 5, maxAttempts: 2 }
+  );
+  // results[0] === 'Illuminate your world with the sun'
+  // results[1] === 'Computing beyond limits'
   ```
 
 - **search-best-first** - Intelligently explore solution spaces

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ import retry from './lib/retry/index.js';
 import searchBestFirst from './lib/search-best-first/index.js';
 import searchJSFiles from './lib/search-js-files/index.js';
 import shortenText from './lib/shorten-text/index.js';
+import bulkMap, { bulkMapRetry } from './lib/bulk-map/index.js';
 import stripNumeric from './lib/strip-numeric/index.js';
 import stripResponse from './lib/strip-response/index.js';
 import toBool from './lib/to-bool/index.js';
@@ -68,11 +69,15 @@ import numberWithUnits from './verblets/number-with-units/index.js';
 import schemaOrg from './verblets/schema-org/index.js';
 // eslint-disable-next-line import/no-named-as-default
 import toObject from './verblets/to-object/index.js';
+// eslint-disable-next-line import/no-named-as-default
+import listMap from './verblets/list-map/index.js';
 
 export { default as retry } from './lib/retry/index.js';
 export { default as stripResponse } from './lib/strip-response/index.js';
 export { default as searchJSFiles } from './lib/search-js-files/index.js';
 export { default as searchBestFirst } from './lib/search-best-first/index.js';
+export { default as bulkMap } from './lib/bulk-map/index.js';
+export { bulkMapRetry } from './lib/bulk-map/index.js';
 
 export const lib = {
   chatGPT,
@@ -81,6 +86,8 @@ export const lib = {
   searchBestFirst,
   searchJSFiles,
   shortenText,
+  bulkMap,
+  bulkMapRetry,
   stripNumeric,
   stripResponse,
   toBool,
@@ -99,6 +106,7 @@ export const verblets = {
   numberWithUnits,
   schemaOrg,
   toObject,
+  listMap,
   anonymize,
   Dismantle,
   list,

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -11,6 +11,7 @@ Modules include:
 - [search-best-first](./search-best-first) – best-first tree search algorithm.
 - [search-js-files](./search-js-files) – locate and analyze JavaScript files.
 - [shorten-text](./shorten-text) – shorten text using an LLM.
+- [bulkmap](./bulk-map) – map lists in retryable batches.
 - [strip-numeric](./strip-numeric) – remove non-digit characters.
 - [strip-response](./strip-response) – clean up model responses.
 - [to-bool](./to-bool) – parse text into a boolean.

--- a/src/lib/bulk-map/README.md
+++ b/src/lib/bulk-map/README.md
@@ -1,0 +1,21 @@
+# bulkmap
+
+Chunk large lists and map each chunk with `listMap`. Failed chunks can be retried.
+`bulkMap` is exported as the default entry.
+
+## Usage
+
+```javascript
+import bulkMap from './index.js';
+
+const films = [
+  'sci-fi epic',
+  'romantic comedy',
+  'time-travel thriller',
+  // ...more titles
+];
+const results = await bulkMap(films, 'Describe each as a Shakespearean play', { chunkSize: 5 });
+// results[0] === 'A saga among the stars'
+// results[1] === 'Where hearts and humor entwine'
+```
+

--- a/src/lib/bulk-map/index.examples.js
+++ b/src/lib/bulk-map/index.examples.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import bulkMap from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('bulkmap examples', () => {
+  it(
+    'maps with listMap',
+    async () => {
+      const animals = ['dog', 'cat', 'cow', 'sheep', 'duck'];
+      const result = await bulkMap(animals, 'Return the sound each animal makes', { chunkSize: 3 });
+      // e.g. result[0] === 'bark'
+      //      result[2] === 'moo'
+      expect(result.length).toBe(5);
+    },
+    longTestTimeout
+  );
+});

--- a/src/lib/bulk-map/index.js
+++ b/src/lib/bulk-map/index.js
@@ -1,0 +1,77 @@
+/* eslint-disable no-await-in-loop */
+import listMap from '../../verblets/list-map/index.js';
+
+/**
+ * Map over a list of fragments by calling `listMap` on newline-delimited batches.
+ * Missing or mismatched output results in `undefined` entries so callers can
+ * selectively retry.
+ *
+ * @param { string[] } list - array of fragments to process
+ * @param { string } instructions - mapping instructions passed to `listMap`
+ * @param { number } [chunkSize=10] - how many items to send per batch
+ * @returns { Promise<(string|undefined)[]> } results aligned with input order
+ */
+async function bulkMap(list, instructions, chunkSize = 10) {
+  const results = new Array(list.length);
+  const promises = [];
+
+  for (let i = 0; i < list.length; i += chunkSize) {
+    const batch = list.slice(i, i + chunkSize);
+    const startIndex = i;
+
+    const p = Promise.resolve()
+      .then(() => listMap(batch, instructions))
+      .then((output) => {
+        if (output.length !== batch.length) {
+          for (let j = 0; j < batch.length; j += 1) {
+            results[startIndex + j] = undefined;
+          }
+          return;
+        }
+        output.forEach((line, j) => {
+          results[startIndex + j] = line;
+        });
+      })
+      .catch(() => {
+        for (let j = 0; j < batch.length; j += 1) {
+          results[startIndex + j] = undefined;
+        }
+      });
+    promises.push(p);
+  }
+
+  await Promise.all(promises);
+  return results;
+}
+
+/**
+ * Retry only the undefined results from `map` until maxAttempts is reached.
+ *
+ * @param { string[] } list - array of fragments
+ * @param { string } instructions - mapping instructions passed to `listMap`
+ * @param { object } [options]
+ * @param { number } [options.chunkSize=10]
+ * @param { number } [options.maxAttempts=3]
+ * @returns { Promise<(string|undefined)[]> }
+ */
+export async function bulkMapRetry(list, instructions, { chunkSize = 10, maxAttempts = 3 } = {}) {
+  const results = await bulkMap(list, instructions, chunkSize);
+  for (let attempt = 1; attempt < maxAttempts; attempt += 1) {
+    const missingIdx = [];
+    const missingFragments = [];
+    results.forEach((val, idx) => {
+      if (val === undefined) {
+        missingIdx.push(idx);
+        missingFragments.push(list[idx]);
+      }
+    });
+    if (missingFragments.length === 0) break;
+    const retryResults = await bulkMap(missingFragments, instructions, chunkSize);
+    retryResults.forEach((val, i) => {
+      results[missingIdx[i]] = val;
+    });
+  }
+  return results;
+}
+
+export default bulkMap;

--- a/src/lib/bulk-map/index.spec.js
+++ b/src/lib/bulk-map/index.spec.js
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import bulkMap, { bulkMapRetry } from './index.js';
+import listMap from '../../verblets/list-map/index.js';
+
+vi.mock('../../verblets/list-map/index.js', () => ({
+  default: vi.fn(async (items, instructions) => {
+    if (items.includes('FAIL')) throw new Error('fail');
+    return items.map((i) => `${i}-${instructions}`);
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('bulkmap', () => {
+  it('maps fragments in batches', async () => {
+    const result = await bulkMap(['a', 'b', 'c'], 'x', 2);
+    expect(result).toStrictEqual(['a-x', 'b-x', 'c-x']);
+    expect(listMap).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves undefined on error', async () => {
+    listMap.mockRejectedValueOnce(new Error('fail'));
+    const result = await bulkMap(['FAIL', 'oops'], 'x', 2);
+    expect(result).toStrictEqual([undefined, undefined]);
+  });
+
+  it('retries only failed fragments', async () => {
+    let call = 0;
+    listMap.mockImplementation(async (items) => {
+      call += 1;
+      if (call === 1) throw new Error('fail');
+      return items.map((l) => l.toUpperCase());
+    });
+
+    const result = await bulkMapRetry(['alpha', 'beta'], 'upper', {
+      chunkSize: 2,
+      maxAttempts: 2,
+    });
+    expect(result).toStrictEqual(['ALPHA', 'BETA']);
+    expect(listMap).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/verblets/README.md
+++ b/src/verblets/README.md
@@ -12,5 +12,6 @@ Available verblets:
 - [number-with-units](./number-with-units)
 - [schema-org](./schema-org)
 - [to-object](./to-object) – see its [README](./to-object/README.md) for details.
+- [list-map](./list-map) - map lists with custom instructions
 
 Use these modules directly or compose them inside [chains](../chains/README.md).

--- a/src/verblets/list-map/README.md
+++ b/src/verblets/list-map/README.md
@@ -1,0 +1,11 @@
+# list-map
+
+Transform a list with a single ChatGPT call by providing mapping instructions.
+The function hides the boilerplate prompting so you only supply the instructions.
+
+```javascript
+import listMap from './index.js';
+
+await listMap(['Budget smartphone', 'Luxury watch'], 'Write a short playful tagline');
+// => ['Affordable tech for everyone', 'Elegance that tells time']
+```

--- a/src/verblets/list-map/index.examples.js
+++ b/src/verblets/list-map/index.examples.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import listMap from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('list-map examples', () => {
+  it(
+    'maps creative slogans',
+    async () => {
+      const items = ['smart toaster', 'robot vacuum'];
+      const result = await listMap(items, 'Give a playful marketing slogan');
+      expect(result.length).toBe(2);
+    },
+    longTestTimeout
+  );
+});

--- a/src/verblets/list-map/index.js
+++ b/src/verblets/list-map/index.js
@@ -1,0 +1,19 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import wrapVariable from '../../prompts/wrap-variable.js';
+
+function buildPrompt(list, instructions) {
+  const instructionsBlock = wrapVariable(instructions, { tag: 'instructions' });
+  const listBlock = wrapVariable(list.join('\n'), { tag: 'list' });
+  return `For each line in <list>, apply the <instructions> to transform it.\nReturn the same number of lines without numbering.\n\n${instructionsBlock}\n${listBlock}`;
+}
+
+export default async function listMap(list, instructions) {
+  const output = await chatGPT(buildPrompt(list, instructions));
+  const lines = output.split('\n');
+  if (lines.length !== list.length) {
+    throw new Error(
+      `Batch output line count mismatch (expected ${list.length}, got ${lines.length})`
+    );
+  }
+  return lines;
+}

--- a/src/verblets/list-map/index.spec.js
+++ b/src/verblets/list-map/index.spec.js
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest';
+import listMap from './index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn(async (prompt) => {
+    const match = prompt.match(/<list>\n([\s\S]*?)\n<\/list>/);
+    const lines = match ? match[1].split('\n') : [];
+    return lines.map((l) => l.toUpperCase()).join('\n');
+  }),
+}));
+
+describe('list-map verblet', () => {
+  it('maps items using instructions', async () => {
+    const result = await listMap(['alpha', 'beta'], 'uppercase');
+    expect(result).toStrictEqual(['ALPHA', 'BETA']);
+  });
+});


### PR DESCRIPTION
## Summary
- rename `bulkmap` helper to `bulk-map`
- expose `bulkMap` as default with named `bulkMapRetry`
- update examples and docs to show more compelling usage

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_683f2e68e6188332b7ec9dca5d9f002f