### PR TITLE
Add bulkReduce chain and listReduce verblet

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Verblets rebuild the basic operations of software with language model intelligen
 - [scan-js](./src/chains/scan-js) - analyze code quality
 - [sort](./src/chains/sort) - order lists by any criteria
 - [summary-map](./src/chains/summary-map) - summarize a collection
+- [bulk-reduce](./src/chains/bulk-reduce) - reduce long lists in batches
 - [test](./src/chains/test) - run LLM-driven tests
 - [test-advice](./src/chains/test-advice) - get feedback on test coverage
 - [veiled-variants](./src/chains/veiled-variants) - conceal sensitive queries with safer framing
@@ -36,6 +37,7 @@ Verblets rebuild the basic operations of software with language model intelligen
 - [schema-org](./src/verblets/schema-org) - create schema.org objects
 - [to-object](./src/verblets/to-object) - convert descriptions to objects
 - [list-map](./src/verblets/list-map) - map lists with custom instructions
+- [list-reduce](./src/verblets/list-reduce) - reduce lists with custom instructions
 
 ### Library Helpers
 
@@ -505,6 +507,19 @@ const inputs = await map.pavedSummaryResult();
   );
   // results[0] === 'Illuminate your world with the sun'
   // results[1] === 'Computing beyond limits'
+  ```
+
+- **bulk-reduce** - Reduce long lists sequentially using `listReduce`
+  ```javascript
+  import bulkReduce from './src/chains/bulk-reduce/index.js';
+
+  const logLines = [
+    'User logged in',
+    'User viewed dashboard',
+    'User logged out'
+  ];
+  const summary = await bulkReduce(logLines, 'Summarize the events');
+  // e.g. 'User session: login, dashboard view and logout'
   ```
 
 - **search-best-first** - Intelligently explore solution spaces

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -11,6 +11,7 @@ Available chains:
 - [scan-js](./scan-js)
 - [sort](./sort)
 - [summary-map](./summary-map)
+- [bulk-reduce](./bulk-reduce)
 - [test](./test)
 - [test-advice](./test-advice)
 - [veiled-variants](./veiled-variants)

--- a/src/chains/bulk-reduce/README.md
+++ b/src/chains/bulk-reduce/README.md
@@ -1,0 +1,12 @@
+# bulk-reduce
+
+Reduce long lists by processing them in smaller batches. Each batch is combined
+with the accumulated result using `listReduce`.
+
+```javascript
+import bulkReduce from './index.js';
+
+const logs = ['step one', 'step two', 'step three'];
+const result = await bulkReduce(logs, 'summarize');
+// => 'summary of steps'
+```

--- a/src/chains/bulk-reduce/index.examples.js
+++ b/src/chains/bulk-reduce/index.examples.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import bulkReduce from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('bulk-reduce examples', () => {
+  it(
+    'reduces a long list sequentially',
+    async () => {
+      const items = ['one', 'two', 'three', 'four'];
+      const result = await bulkReduce(items, 'concatenate', { chunkSize: 2 });
+      expect(result).toBeDefined();
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/bulk-reduce/index.js
+++ b/src/chains/bulk-reduce/index.js
@@ -1,0 +1,11 @@
+import listReduce from '../../verblets/list-reduce/index.js';
+
+export default async function bulkReduce(list, instructions, { chunkSize = 10, initial } = {}) {
+  let acc = initial;
+  for (let i = 0; i < list.length; i += chunkSize) {
+    const batch = list.slice(i, i + chunkSize);
+    // eslint-disable-next-line no-await-in-loop
+    acc = await listReduce(acc, batch, instructions);
+  }
+  return acc;
+}

--- a/src/chains/bulk-reduce/index.spec.js
+++ b/src/chains/bulk-reduce/index.spec.js
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import bulkReduce from './index.js';
+import listReduce from '../../verblets/list-reduce/index.js';
+
+vi.mock('../../verblets/list-reduce/index.js', () => ({
+  default: vi.fn(async (acc, list) => [acc, ...list].filter(Boolean).join('-')),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('bulk-reduce chain', () => {
+  it('reduces in batches', async () => {
+    const result = await bulkReduce(['a', 'b', 'c', 'd'], 'join', { chunkSize: 2 });
+    expect(result).toBe('a-b-c-d');
+    expect(listReduce).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses initial value', async () => {
+    const result = await bulkReduce(['x', 'y'], 'join', { initial: '0', chunkSize: 2 });
+    expect(result).toBe('0-x-y');
+    expect(listReduce).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/verblets/README.md
+++ b/src/verblets/README.md
@@ -13,5 +13,6 @@ Available verblets:
 - [schema-org](./schema-org)
 - [to-object](./to-object) – see its [README](./to-object/README.md) for details.
 - [list-map](./list-map) - map lists with custom instructions
+- [list-reduce](./list-reduce) - reduce lists with custom instructions
 
 Use these modules directly or compose them inside [chains](../chains/README.md).

--- a/src/verblets/list-reduce/README.md
+++ b/src/verblets/list-reduce/README.md
@@ -1,0 +1,10 @@
+# list-reduce
+
+Combine an accumulator value with a list of strings using custom instructions in a single ChatGPT call. Returns the final accumulator.
+
+```javascript
+import listReduce from './index.js';
+
+await listReduce('', ['alpha', 'beta', 'gamma'], 'Concatenate them');
+// => 'alpha beta gamma'
+```

--- a/src/verblets/list-reduce/index.examples.js
+++ b/src/verblets/list-reduce/index.examples.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import listReduce from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('list-reduce examples', () => {
+  it(
+    'combines items with custom instructions',
+    async () => {
+      const result = await listReduce('', ['red', 'green', 'blue'], 'join with commas');
+      expect(result.length).toBeGreaterThan(0);
+    },
+    longTestTimeout
+  );
+});

--- a/src/verblets/list-reduce/index.js
+++ b/src/verblets/list-reduce/index.js
@@ -1,0 +1,14 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import wrapVariable from '../../prompts/wrap-variable.js';
+
+function buildPrompt(acc, list, instructions) {
+  const instructionsBlock = wrapVariable(instructions, { tag: 'instructions' });
+  const accBlock = wrapVariable(acc, { tag: 'accumulator' });
+  const listBlock = wrapVariable(list.join('\n'), { tag: 'list' });
+  return `Start with the <accumulator>. Apply the <instructions> to each item in <list> sequentially, using the result as the new accumulator each time. Return only the final accumulator.\n\n${instructionsBlock}\n${accBlock}\n${listBlock}`;
+}
+
+export default async function listReduce(acc, list, instructions) {
+  const output = await chatGPT(buildPrompt(acc, list, instructions));
+  return output.trim();
+}

--- a/src/verblets/list-reduce/index.spec.js
+++ b/src/verblets/list-reduce/index.spec.js
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+import listReduce from './index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn(async (prompt) => {
+    const listMatch = prompt.match(/<list>\n([\s\S]*?)\n<\/list>/);
+    const lines = listMatch ? listMatch[1].split('\n') : [];
+    const accMatch = prompt.match(/<accumulator>([\s\S]*?)<\/accumulator>/);
+    const acc = accMatch ? accMatch[1].trim() : '';
+    return [acc, ...lines].filter(Boolean).join('+');
+  }),
+}));
+
+describe('list-reduce verblet', () => {
+  it('reduces items using instructions', async () => {
+    const result = await listReduce('0', ['a', 'b', 'c'], 'join');
+    expect(result).toBe('0+a+b+c');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `list-reduce` verblet
- create `bulk-reduce` chain using `listReduce`
- document new modules in READMEs
- test new functions
- fix listReduce API and bulkReduce usage

## Testing
- `npm run lint` *(fails: command not found)*
- `npm run test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f97d520508332a452e87eca2eed6d