### PR TITLE
Implement polysemy disambiguation chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Verblets rebuild the basic operations of software with language model intelligen
 
 - [anonymize](./src/chains/anonymize) - scrub personal details from text
 - [dismantle](./src/chains/dismantle) - break systems into components
+- [disambiguate](./src/chains/disambiguate) - resolve ambiguous terms
 - [list](./src/chains/list) - generate contextual lists
 - [questions](./src/chains/questions) - produce clarifying questions
 - [scan-js](./src/chains/scan-js) - analyze code quality
@@ -284,6 +285,15 @@ const { path } = await searchBestFirst({
   //   - Spokes: DT Swiss Aerolite
   // ...continues with full component breakdown
   ```
+
+- **disambiguate** - Resolve the intended meaning of a polysemous term
+```javascript
+const meaning = await disambiguate({
+  term: 'bark',
+  context: 'I heard the bark while walking in the forest.'
+});
+// => { term: 'bark', sense: 'dog sound' }
+```
 
 - **summary-map** - Compress many inputs into one high-cost LLM prompt
 ```javascript

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -6,6 +6,7 @@ Available chains:
 
 - [anonymize](./anonymize)
 - [dismantle](./dismantle)
+- [disambiguate](./disambiguate)
 - [list](./list)
 - [questions](./questions)
 - [scan-js](./scan-js)

--- a/src/chains/disambiguate/README.md
+++ b/src/chains/disambiguate/README.md
@@ -1,0 +1,13 @@
+# disambiguate
+
+Resolve polysemous terms to the most appropriate meaning using surrounding context.
+
+```javascript
+import disambiguate from './index.js';
+
+const result = await disambiguate({
+  term: 'bark',
+  context: 'I heard the bark while walking in the forest.'
+});
+// => { term: 'bark', sense: 'dog sound' }
+```

--- a/src/chains/disambiguate/index.examples.js
+++ b/src/chains/disambiguate/index.examples.js
@@ -1,0 +1,7 @@
+import disambiguate from './index.js';
+
+const example = await disambiguate({
+  term: 'bark',
+  context: 'I heard the bark while walking in the forest',
+});
+console.log(example);

--- a/src/chains/disambiguate/index.js
+++ b/src/chains/disambiguate/index.js
@@ -1,0 +1,35 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import { constants as promptConstants } from '../../prompts/index.js';
+import toObject from '../../verblets/to-object/index.js';
+import enums from '../../verblets/enum/index.js';
+
+const { onlyJSONStringArray, onlyJSON } = promptConstants;
+
+const sensesPrompt = (term) => `
+${onlyJSONStringArray}
+List the distinct meanings of the word "${term}" without explanations.
+${onlyJSONStringArray}
+`;
+
+const chooseSensePrompt = (term, context, senses) => {
+  const choices = senses.map((s) => `- ${s}`).join('\n');
+  return `
+${onlyJSON}
+Determine which meaning of "${term}" best fits the context below.
+<choices>
+${choices}
+</choices>
+<context>
+${context}
+</context>
+Return an object with "sense" and a short "reason".
+${onlyJSON}`;
+};
+
+export default async ({ term, context }) => {
+  const sensesText = await chatGPT(sensesPrompt(term));
+  const senses = await toObject(sensesText);
+  const sensesEnum = senses.reduce((acc, s, idx) => ({ ...acc, [s]: idx }), {});
+  const senseName = await enums(chooseSensePrompt(term, context, senses), sensesEnum);
+  return { term, sense: senseName };
+};

--- a/src/chains/disambiguate/index.spec.js
+++ b/src/chains/disambiguate/index.spec.js
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import disambiguate from './index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn().mockImplementation((text) => {
+    if (/List the distinct meanings/.test(text)) {
+      return '["dog sound","tree outer layer"]';
+    }
+    if (/best fits the context/.test(text)) {
+      return '"dog sound"';
+    }
+    return 'undefined';
+  }),
+}));
+
+describe('disambiguate chain', () => {
+  it('selects meaning based on context', async () => {
+    const result = await disambiguate({ term: 'bark', context: 'The dog bark was loud' });
+    expect(result).toEqual({ term: 'bark', sense: 'dog sound' });
+  });
+});

--- a/src/verblets/list-reduce/index.spec.js
+++ b/src/verblets/list-reduce/index.spec.js
@@ -5,7 +5,9 @@ vi.mock('../../lib/chatgpt/index.js', () => ({
   default: vi.fn(async (prompt) => {
     const listMatch = prompt.match(/<list>\n([\s\S]*?)\n<\/list>/);
     const lines = listMatch ? listMatch[1].split('\n') : [];
-    const accMatch = prompt.match(/<accumulator>([\s\S]*?)<\/accumulator>/);
+    const accMatch =
+      prompt.match(/<accumulator>([\s\S]*?)<\/accumulator>/) ||
+      [...prompt.matchAll(/"([^"]*)"/g)][1];
     const acc = accMatch ? accMatch[1].trim() : '';
     return [acc, ...lines].filter(Boolean).join('+');
   }),


### PR DESCRIPTION
## Summary
- add new **disambiguate** chain to resolve word senses from context
- document the chain
- integrate chain in lists of available chains
- provide README example for disambiguation
- adjust list-reduce spec to support current prompt format

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_683fb9375afc83329cffbf915835086f