### PR TITLE
Add llm-expect verbllet

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Verblets rebuild the basic operations of software with language model intelligen
 - [to-object](./src/verblets/to-object) - convert descriptions to objects
 - [list-map](./src/verblets/list-map) - map lists with custom instructions
 - [list-reduce](./src/verblets/list-reduce) - reduce lists with custom instructions
+- [llm-expect](./src/verblets/llm-expect) - assert using an LLM
 
 ### Library Helpers
 

--- a/src/verblets/README.md
+++ b/src/verblets/README.md
@@ -15,5 +15,6 @@ Available verblets:
 - [list-map](./list-map) - map lists with custom instructions
 - [list-reduce](./list-reduce) - reduce lists with custom instructions
 - [list-partition](./list-partition) - partition lists with custom instructions and optional category list
+- [llm-expect](./llm-expect) - make test assertions with an LLM
 
 Use these modules directly or compose them inside [chains](../chains/README.md).

--- a/src/verblets/list-reduce/index.spec.js
+++ b/src/verblets/list-reduce/index.spec.js
@@ -4,7 +4,7 @@ import listReduce from './index.js';
 vi.mock('../../lib/chatgpt/index.js', () => ({
   default: vi.fn((prompt) => {
     const listMatch = prompt.match(/<list>\n([\s\S]*?)\n<\/list>/);
-    const accMatch = prompt.match(/"([^"]+)"\s*<list>/);
+    const accMatch = prompt.match(/<accumulator>\n([\s\S]*?)\n<\/accumulator>/);
 
     if (listMatch && accMatch) {
       const acc = accMatch[1];

--- a/src/verblets/llm-expect/index.examples.js
+++ b/src/verblets/llm-expect/index.examples.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import llmExpect from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+const examples = [
+  {
+    inputs: { actual: 'hello', expected: 'hello' },
+    want: { result: true },
+  },
+  {
+    inputs: { actual: 'hello world', constraint: 'Is this a greeting?' },
+    want: { result: true },
+  },
+];
+
+describe('llm-expect verbllet', () => {
+  examples.forEach((example) => {
+    it(
+      example.inputs.constraint || 'equality',
+      async () => {
+        const result = await llmExpect(
+          example.inputs.actual,
+          example.inputs.expected,
+          example.inputs.constraint
+        );
+        expect(result).toStrictEqual(example.want.result);
+      },
+      longTestTimeout
+    );
+  });
+});

--- a/src/verblets/llm-expect/index.js
+++ b/src/verblets/llm-expect/index.js
@@ -1,0 +1,42 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import stripResponse from '../../lib/strip-response/index.js';
+import toBool from '../../lib/to-bool/index.js';
+import { constants as promptConstants, wrapVariable } from '../../prompts/index.js';
+
+const {
+  asBool,
+  asUndefinedByDefault,
+  contentIsQuestion,
+  explainAndSeparate,
+  explainAndSeparatePrimitive,
+} = promptConstants;
+
+export default async (actual, expectedOrConstraint, maybeConstraint, options = {}) => {
+  let expected;
+  let constraint = '';
+
+  if (typeof maybeConstraint === 'undefined') {
+    expected = expectedOrConstraint;
+  } else {
+    expected = expectedOrConstraint;
+    constraint = maybeConstraint;
+  }
+
+  if (!constraint) {
+    constraint = 'Does the actual value strictly equal the expected value?';
+  }
+
+  const parts = [
+    contentIsQuestion,
+    wrapVariable(JSON.stringify(actual), { tag: 'actual' }),
+    expected !== undefined ? wrapVariable(JSON.stringify(expected), { tag: 'expected' }) : '',
+    wrapVariable(constraint, { tag: 'constraint' }),
+    '',
+    `${explainAndSeparate} ${explainAndSeparatePrimitive}`,
+    `${asBool} ${asUndefinedByDefault}`,
+  ];
+
+  const prompt = parts.filter(Boolean).join('\n');
+  const response = await chatGPT(prompt, { ...options });
+  return toBool(stripResponse(response));
+};

--- a/src/verblets/llm-expect/index.spec.js
+++ b/src/verblets/llm-expect/index.spec.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import llmExpect from './index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn().mockImplementation((prompt) => {
+    if (/greeting/.test(prompt)) {
+      return 'True';
+    }
+    if (/strictly equal/.test(prompt)) {
+      if (/"hello"/.test(prompt) && /"bye"/.test(prompt)) {
+        return 'False';
+      }
+      if (prompt.match(/"hello"/g)?.length >= 2) {
+        return 'True';
+      }
+    }
+    return 'False';
+  }),
+}));
+
+const examples = [
+  {
+    name: 'Equality check',
+    inputs: { actual: 'hello', expected: 'hello' },
+    want: { result: true },
+  },
+  {
+    name: 'Constraint check',
+    inputs: {
+      actual: 'hello world',
+      constraint: 'Is this a greeting',
+    },
+    want: { result: true },
+  },
+  {
+    name: 'Mismatch returns false',
+    inputs: { actual: 'hello', expected: 'bye' },
+    want: { result: false },
+  },
+];
+
+describe('llm-expect verblet', () => {
+  examples.forEach((example) => {
+    it(example.name, async () => {
+      const result = await llmExpect(
+        example.inputs.actual,
+        example.inputs.expected,
+        example.inputs.constraint
+      );
+      expect(result).toStrictEqual(example.want.result);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add new `llm-expect` verbllet for LLM-powered assertions
- add example usage and tests
- update verbllet docs
- fix list-reduce test mock for updated prompt format

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_68426899bb388332a15ddfca56470840