### PR TITLE
Add polysemy chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Verblets rebuild the basic operations of software with language model intelligen
 - [scan-js](./src/chains/scan-js) - analyze code quality
 - [sort](./src/chains/sort) - order lists by any criteria
 - [summary-map](./src/chains/summary-map) - summarize a collection
+- [polysemy](./src/chains/polysemy) - extract ambiguous terms
 - [bulk-map](./src/chains/bulk-map/) - map over long lists in batches
 - [bulk-reduce](./src/chains/bulk-reduce) - reduce long lists in batches
 - [bulk-partition](./src/chains/bulk-partition) - partition long lists in batches

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -12,6 +12,7 @@ Available chains:
 - [scan-js](./scan-js)
 - [sort](./sort)
 - [summary-map](./summary-map)
+- [polysemy](./polysemy)
 - [bulk-reduce](./bulk-reduce)
 - [bulk-partition](./bulk-partition)
 - [test](./test)

--- a/src/chains/polysemy/README.md
+++ b/src/chains/polysemy/README.md
@@ -1,0 +1,11 @@
+# polysemy
+
+Extract the most ambiguous or polysemous terms from a block of text. The chain splits long inputs into manageable chunks and uses `bulkMap` to identify candidates from each chunk. Results are ranked by frequency so the most ambiguous terms appear first.
+
+```javascript
+import polysemy from './index.js';
+
+const text = `The old port near the river was quieter than the USB port on my laptop.`;
+const terms = await polysemy(text, { topN: 3 });
+// => ['port', '...']
+```

--- a/src/chains/polysemy/index.examples.js
+++ b/src/chains/polysemy/index.examples.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { longTestTimeout } from '../../constants/common.js';
+import polysemy from './index.js';
+
+describe('polysemy example', () => {
+  it(
+    'extracts polysemous terms from text',
+    async () => {
+      const text = `I went to the bank to watch the bat fly over the dark river bank.`;
+      const terms = await polysemy(text, { topN: 2 });
+      expect(terms.length).greaterThan(0);
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/polysemy/index.js
+++ b/src/chains/polysemy/index.js
@@ -1,0 +1,48 @@
+import * as R from 'ramda';
+import { bulkMapRetry } from '../bulk-map/index.js';
+import modelService from '../../services/llm-model/index.js';
+
+export const chunkByTokens = (text, maxTokens, model = modelService.getBestPublicModel()) => {
+  const words = text.split(/\s+/);
+  const chunks = [];
+  let current = [];
+  let count = 0;
+  words.forEach((word) => {
+    const tokens = model.toTokens(word).length;
+    if (count + tokens > maxTokens && current.length) {
+      chunks.push(current.join(' '));
+      current = [word];
+      count = tokens;
+    } else {
+      current.push(word);
+      count += tokens;
+    }
+  });
+  if (current.length) {
+    chunks.push(current.join(' '));
+  }
+  return chunks;
+};
+
+const mapInstructions =
+  'List up to 5 polysemous or ambiguous terms or short phrases found in the text. ' +
+  'Return them as a comma-separated list without any other text.';
+
+export default async function polysemy(text, { chunkTokens = 800, topN = 10 } = {}) {
+  const model = modelService.getBestPublicModel();
+  const chunks = chunkByTokens(text, chunkTokens, model);
+  const results = await bulkMapRetry(chunks, mapInstructions, { chunkSize: 5 });
+
+  const terms = results.filter(Boolean).flatMap((r) =>
+    r
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+  );
+
+  const counts = R.countBy(R.identity, terms);
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, topN)
+    .map(([term]) => term);
+}

--- a/src/chains/polysemy/index.spec.js
+++ b/src/chains/polysemy/index.spec.js
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import polysemy, { chunkByTokens } from './index.js';
+import { bulkMapRetry } from '../bulk-map/index.js';
+import modelService from '../../services/llm-model/index.js';
+
+vi.mock('../bulk-map/index.js', () => ({
+  bulkMapRetry: vi.fn(),
+}));
+
+vi.mock('../../services/llm-model/index.js', () => ({
+  default: {
+    getBestPublicModel: vi.fn().mockReturnValue({
+      toTokens: (text) => text.split(/\s+/),
+    }),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('polysemy chain', () => {
+  it('chunks text by tokens', () => {
+    const model = modelService.getBestPublicModel();
+    const chunks = chunkByTokens('a b c d e', 2, model);
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+
+  it('returns ranked terms', async () => {
+    bulkMapRetry.mockResolvedValue(['bank, port', 'port, note', undefined]);
+    const result = await polysemy('irrelevant', { topN: 2 });
+    expect(result).toStrictEqual(['port', 'bank']);
+    expect(bulkMapRetry).toHaveBeenCalled();
+  });
+});

--- a/src/verblets/list-reduce/index.spec.js
+++ b/src/verblets/list-reduce/index.spec.js
@@ -4,7 +4,7 @@ import listReduce from './index.js';
 vi.mock('../../lib/chatgpt/index.js', () => ({
   default: vi.fn((prompt) => {
     const listMatch = prompt.match(/<list>\n([\s\S]*?)\n<\/list>/);
-    const accMatch = prompt.match(/"([^"]+)"\s*<list>/);
+    const accMatch = prompt.match(/<accumulator>\n([\s\S]*?)\n<\/accumulator>/);
 
     if (listMatch && accMatch) {
       const acc = accMatch[1];


### PR DESCRIPTION
## Summary
- create polysemy chain to extract polysemous terms
- document chain
- show example usage
- add unit tests
- register chain in READMEs
- fix failing list-reduce test regex

## Testing
- `npm run lint`
- `CI=1 npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_68427022cdf88332b94eefdb5ddcaca3