### PR TITLE
Add list-find verblet and bulk-find chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ List operations transform, filter, and organize collections using natural langua
 
 - [bulk-map](./src/chains/bulk-map) - process long lists in retryable batches
 - [bulk-reduce](./src/chains/bulk-reduce) - reduce long lists in manageable chunks
+- [bulk-find](./src/chains/bulk-find) - locate the best match in large datasets
 - [bulk-group](./src/chains/bulk-group) - group large datasets efficiently
 - [list-map](./src/verblets/list-map) - transform each item in a list
 - [list-reduce](./src/verblets/list-reduce) - combine list items using custom logic
+- [list-find](./src/verblets/list-find) - pick the single best item from a list
 - [list-filter](./src/verblets/list-filter) - filter lists with natural language criteria
 - [list-group](./src/verblets/list-group) - categorize list items into groups
 - [list-expand](./src/verblets/list-expand) - generate additional similar items

--- a/src/chains/bulk-find/README.md
+++ b/src/chains/bulk-find/README.md
@@ -1,0 +1,16 @@
+# bulk-find
+
+Scan long lists in manageable batches to locate the item that best matches your instructions.
+
+```javascript
+import bulkFind from './index.js';
+
+const emails = [
+  'update from accounting',
+  'party invitation',
+  'weekly newsletter',
+  // ... potentially thousands more
+];
+const best = await bulkFind(emails, 'Which email is most urgent?');
+// => 'update from accounting'
+```

--- a/src/chains/bulk-find/index.examples.js
+++ b/src/chains/bulk-find/index.examples.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import bulkFind from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('bulk-find examples', () => {
+  it(
+    'finds the best match across batches',
+    async () => {
+      const titles = [
+        'ancient mystery',
+        'space odyssey',
+        'underwater adventure',
+        'future tech thriller',
+      ];
+      const result = await bulkFind(titles, 'Which title feels most futuristic?', { chunkSize: 2 });
+      expect(result).toBeDefined();
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/bulk-find/index.js
+++ b/src/chains/bulk-find/index.js
@@ -1,0 +1,32 @@
+import listFind from '../../verblets/list-find/index.js';
+
+export const bulkFind = async function (list, instructions, chunkSize = 10) {
+  let candidate = '';
+  for (let i = 0; i < list.length; i += chunkSize) {
+    const batch = list.slice(i, i + chunkSize);
+    const combined = candidate ? [candidate, ...batch] : batch;
+    // eslint-disable-next-line no-await-in-loop
+    candidate = await listFind(combined, instructions);
+  }
+  return candidate;
+};
+
+export const bulkFindRetry = async function (
+  list,
+  instructions,
+  { chunkSize = 10, maxAttempts = 3 } = {}
+) {
+  let result;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      result = await bulkFind(list, instructions, chunkSize);
+      if (result) break;
+    } catch {
+      // continue
+    }
+  }
+  return result;
+};
+
+export default bulkFind;

--- a/src/chains/bulk-find/index.spec.js
+++ b/src/chains/bulk-find/index.spec.js
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import bulkFind, { bulkFindRetry } from './index.js';
+import listFind from '../../verblets/list-find/index.js';
+
+vi.mock('../../verblets/list-find/index.js', () => ({
+  default: vi.fn(async (items) => items[items.length - 1]),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('bulk-find chain', () => {
+  it('scans batches to find best item', async () => {
+    const result = await bulkFind(['a', 'b', 'c', 'd'], 'find', 2);
+    expect(result).toBe('d');
+    expect(listFind).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on failure', async () => {
+    listFind.mockRejectedValueOnce(new Error('fail'));
+    const result = await bulkFindRetry(['x', 'y'], 'find', { chunkSize: 2, maxAttempts: 2 });
+    expect(result).toBe('y');
+    expect(listFind).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ import searchBestFirst from './lib/search-best-first/index.js';
 import searchJSFiles from './lib/search-js-files/index.js';
 import shortenText from './lib/shorten-text/index.js';
 import bulkMap, { bulkMapRetry } from './chains/bulk-map/index.js';
+import bulkFind, { bulkFindRetry } from './chains/bulk-find/index.js';
 import stripNumeric from './lib/strip-numeric/index.js';
 import stripResponse from './lib/strip-response/index.js';
 import toBool from './lib/to-bool/index.js';
@@ -71,6 +72,7 @@ import schemaOrg from './verblets/schema-org/index.js';
 import toObject from './verblets/to-object/index.js';
 
 import listMap from './verblets/list-map/index.js';
+import listFind from './verblets/list-find/index.js';
 
 import bulkGroup from './chains/bulk-group/index.js';
 
@@ -80,7 +82,7 @@ export { default as retry } from './lib/retry/index.js';
 export { default as stripResponse } from './lib/strip-response/index.js';
 export { default as searchJSFiles } from './lib/search-js-files/index.js';
 export { default as searchBestFirst } from './lib/search-best-first/index.js';
-export { bulkMap, bulkMapRetry };
+export { bulkMap, bulkMapRetry, bulkFind, bulkFindRetry };
 
 export const lib = {
   chatGPT,
@@ -108,7 +110,9 @@ export const verblets = {
   schemaOrg,
   toObject,
   listMap,
+  listFind,
   bulkMap,
+  bulkFind,
   anonymize,
   Dismantle,
   list,

--- a/src/verblets/list-find/README.md
+++ b/src/verblets/list-find/README.md
@@ -1,0 +1,11 @@
+# list-find
+
+Find the single best match in a list using natural language instructions.
+
+```javascript
+import listFind from './index.js';
+
+const snacks = ['apple pie', 'fruit roll-up', 'carrot sticks'];
+await listFind(snacks, 'which snack feels most nostalgic for kids of the 90s?');
+// => 'fruit roll-up'
+```

--- a/src/verblets/list-find/index.examples.js
+++ b/src/verblets/list-find/index.examples.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import listFind from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('list-find examples', () => {
+  it(
+    'finds the item that best fits the instructions',
+    async () => {
+      const books = ['space adventure', 'medieval romance', 'futuristic mystery'];
+      const result = await listFind(books, 'which book sounds most futuristic?');
+      expect(result).toBeDefined();
+    },
+    longTestTimeout
+  );
+});

--- a/src/verblets/list-find/index.js
+++ b/src/verblets/list-find/index.js
@@ -1,0 +1,13 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import wrapVariable from '../../prompts/wrap-variable.js';
+
+const buildPrompt = (list, instructions) => {
+  const instructionsBlock = wrapVariable(instructions, { tag: 'instructions' });
+  const listBlock = wrapVariable(list.join('\n'), { tag: 'list' });
+  return `From the <list>, select the single item that best satisfies the <instructions>. If none apply, return an empty string.\n\n${instructionsBlock}\n${listBlock}`;
+};
+
+export default async function listFind(list, instructions) {
+  const output = await chatGPT(buildPrompt(list, instructions));
+  return output.trim();
+}

--- a/src/verblets/list-find/index.spec.js
+++ b/src/verblets/list-find/index.spec.js
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+import listFind from './index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn(async (prompt) => {
+    const listMatch = prompt.match(/<list>\n([\s\S]*?)\n<\/list>/);
+    const lines = listMatch ? listMatch[1].split('\n') : [];
+    const parts = prompt.split('"');
+    const letter = [...parts].reverse().find((p) => /^[a-z]+$/i.test(p.trim())) || '';
+    return lines.find((l) => l.includes(letter)) || '';
+  }),
+}));
+
+describe('list-find verblet', () => {
+  it('finds item using instructions', async () => {
+    const result = await listFind(['alpha', 'beta', 'gamma'], 'find "b"');
+    expect(result).toBe('beta');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `listFind` verblet and docs
- create `bulkFind` chain with retry logic
- export new utilities
- document new modules in README
- add unit tests and examples

## Testing
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_6845328503f88332a90dc364992bdc77