### PR TITLE
Add bulkFilter chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ List operations transform, filter, and organize collections using natural langua
 - [bulk-reduce](./src/chains/bulk-reduce) - reduce long lists in manageable chunks
 - [bulk-find](./src/chains/bulk-find) - locate the best match in large datasets
 - [bulk-group](./src/chains/bulk-group) - group large datasets efficiently
+- [bulk-filter](./src/chains/bulk-filter) - filter huge lists in batches
 - [list-map](./src/verblets/list-map) - transform each item in a list
 - [list-reduce](./src/verblets/list-reduce) - combine list items using custom logic
 - [list-find](./src/verblets/list-find) - pick the single best item from a list

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -14,6 +14,7 @@ Available chains:
 - [summary-map](./summary-map)
 - [bulk-reduce](./bulk-reduce)
 - [bulk-group](./bulk-group)
+- [bulk-filter](./bulk-filter)
 - [test](./test)
 - [test-advice](./test-advice)
 - [veiled-variants](./veiled-variants)

--- a/src/chains/bulk-filter/README.md
+++ b/src/chains/bulk-filter/README.md
@@ -1,0 +1,21 @@
+# bulk-filter
+
+Filter very long lists in manageable chunks using `listFilter`. Failed batches can be retried.
+
+```javascript
+import bulkFilter from './index.js';
+
+const diary = [
+  'Walked the dog and bought milk.',
+  'One day I hope to sail across the Atlantic.',
+  'Cleaned out the garage.',
+  "Maybe I'll start that bakery I keep dreaming about.",
+];
+
+const aspirations = await bulkFilter(
+  diary,
+  'Keep only lines about hopes or big dreams',
+  { chunkSize: 2 }
+);
+// => ['One day I hope to sail across the Atlantic.', "Maybe I'll start that bakery I keep dreaming about."]
+```

--- a/src/chains/bulk-filter/index.examples.js
+++ b/src/chains/bulk-filter/index.examples.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import bulkFilter from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('bulk-filter examples', () => {
+  it(
+    'filters with listFilter',
+    async () => {
+      const notes = [
+        'Saw a dolphin while surfing',
+        'Finished laundry',
+        'Dream of traveling to Iceland',
+        'Paid the electricity bill',
+      ];
+      const dreams = await bulkFilter(notes, 'keep only lines about aspirations or dreams', {
+        chunkSize: 2,
+      });
+      expect(dreams.length).toBeGreaterThan(0);
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/bulk-filter/index.js
+++ b/src/chains/bulk-filter/index.js
@@ -1,0 +1,59 @@
+import listFilter from '../../verblets/list-filter/index.js';
+
+const buildMask = async (list, instructions, chunkSize) => {
+  const mask = new Array(list.length);
+  for (let i = 0; i < list.length; i += chunkSize) {
+    const batch = list.slice(i, i + chunkSize);
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await listFilter(batch, instructions);
+      const valid = result.every((item) => batch.includes(item));
+      if (!valid) {
+        for (let j = 0; j < batch.length; j += 1) {
+          mask[i + j] = undefined;
+        }
+        continue;
+      }
+      for (let j = 0; j < batch.length; j += 1) {
+        mask[i + j] = result.includes(batch[j]);
+      }
+    } catch {
+      for (let j = 0; j < batch.length; j += 1) {
+        mask[i + j] = undefined;
+      }
+    }
+  }
+  return mask;
+};
+
+export const bulkFilterRetry = async (
+  list,
+  instructions,
+  { chunkSize = 10, maxAttempts = 3 } = {}
+) => {
+  let mask = await buildMask(list, instructions, chunkSize);
+  for (let attempt = 1; attempt < maxAttempts; attempt += 1) {
+    const missingIdx = [];
+    const missingItems = [];
+    mask.forEach((val, idx) => {
+      if (val === undefined) {
+        missingIdx.push(idx);
+        missingItems.push(list[idx]);
+      }
+    });
+    if (missingItems.length === 0) break;
+    // eslint-disable-next-line no-await-in-loop
+    const retryMask = await buildMask(missingItems, instructions, chunkSize);
+    retryMask.forEach((val, i) => {
+      if (val !== undefined) {
+        mask[missingIdx[i]] = val;
+      }
+    });
+  }
+  return list.filter((_, idx) => mask[idx]);
+};
+
+export default async function bulkFilter(list, instructions, { chunkSize = 10 } = {}) {
+  const mask = await buildMask(list, instructions, chunkSize);
+  return list.filter((_, idx) => mask[idx]);
+}

--- a/src/chains/bulk-filter/index.spec.js
+++ b/src/chains/bulk-filter/index.spec.js
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import bulkFilter, { bulkFilterRetry } from './index.js';
+import listFilter from '../../verblets/list-filter/index.js';
+
+vi.mock('../../verblets/list-filter/index.js', () => ({
+  default: vi.fn(async (items, instructions) => {
+    if (items.includes('FAIL')) throw new Error('fail');
+    return items.filter((l) => l.includes(instructions));
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('bulk-filter', () => {
+  it('filters items in batches', async () => {
+    const result = await bulkFilter(['a', 'b', 'c'], 'a', { chunkSize: 2 });
+    expect(result).toStrictEqual(['a']);
+    expect(listFilter).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries failed batches', async () => {
+    let call = 0;
+    listFilter.mockImplementation(async (items) => {
+      call += 1;
+      if (call === 1) throw new Error('fail');
+      return items.filter((l) => l.includes('a'));
+    });
+
+    const result = await bulkFilterRetry(['FAIL', 'a', 'b'], 'a', {
+      chunkSize: 2,
+      maxAttempts: 2,
+    });
+    expect(result).toStrictEqual(['a']);
+    expect(listFilter).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ import searchJSFiles from './lib/search-js-files/index.js';
 import shortenText from './lib/shorten-text/index.js';
 import bulkMap, { bulkMapRetry } from './chains/bulk-map/index.js';
 import bulkFind, { bulkFindRetry } from './chains/bulk-find/index.js';
+import bulkFilter, { bulkFilterRetry } from './chains/bulk-filter/index.js';
 import stripNumeric from './lib/strip-numeric/index.js';
 import stripResponse from './lib/strip-response/index.js';
 import toBool from './lib/to-bool/index.js';
@@ -82,7 +83,7 @@ export { default as retry } from './lib/retry/index.js';
 export { default as stripResponse } from './lib/strip-response/index.js';
 export { default as searchJSFiles } from './lib/search-js-files/index.js';
 export { default as searchBestFirst } from './lib/search-best-first/index.js';
-export { bulkMap, bulkMapRetry, bulkFind, bulkFindRetry };
+export { bulkMap, bulkMapRetry, bulkFind, bulkFindRetry, bulkFilter, bulkFilterRetry };
 
 export const lib = {
   chatGPT,
@@ -123,6 +124,7 @@ export const verblets = {
   test,
   testAdvice,
   bulkGroup,
+  bulkFilter,
   listGroup,
 };
 


### PR DESCRIPTION
## Summary
- add a `bulk-filter` chain with retry logic
- document the new chain and link it from README files
- expose `bulkFilter` from the library

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_684533762da48332bb9630204c2352b2