### PR TITLE
Add name verblet

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Content utilities generate, transform, and analyze text while maintaining struct
 - [list](./src/chains/list) - generate contextual lists from prompts
 - [questions](./src/chains/questions) - produce clarifying questions for topics
 - [schema-org](./src/verblets/schema-org) - create schema.org-compliant data structures
-- [name](./src/verblets/name) - propose short names for datasets
+- [name](./src/verblets/name) - name something from a definition or description
 - [to-object](./src/verblets/to-object) - convert descriptions to structured objects
 - [veiled-variants](./src/chains/veiled-variants) - rephrase sensitive queries safely
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Content utilities generate, transform, and analyze text while maintaining struct
 - [list](./src/chains/list) - generate contextual lists from prompts
 - [questions](./src/chains/questions) - produce clarifying questions for topics
 - [schema-org](./src/verblets/schema-org) - create schema.org-compliant data structures
+- [name](./src/verblets/name) - propose short names for datasets
 - [to-object](./src/verblets/to-object) - convert descriptions to structured objects
 - [veiled-variants](./src/chains/veiled-variants) - rephrase sensitive queries safely
 

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,8 @@ import numberWithUnits from './verblets/number-with-units/index.js';
 
 import schemaOrg from './verblets/schema-org/index.js';
 
+import name from './verblets/name/index.js';
+
 import toObject from './verblets/to-object/index.js';
 
 import listMap from './verblets/list-map/index.js';
@@ -106,6 +108,7 @@ export const verblets = {
   number,
   numberWithUnits,
   schemaOrg,
+  name,
   toObject,
   listMap,
   bulkMap,

--- a/src/verblets/README.md
+++ b/src/verblets/README.md
@@ -12,6 +12,7 @@ Available verblets:
 - [number-with-units](./number-with-units)
 - [sentiment](./sentiment) - classify text sentiment
 - [schema-org](./schema-org)
+- [name](./name) - suggest concise names for data
 - [to-object](./to-object) – see its [README](./to-object/README.md) for details.
 - [list-map](./list-map) - map lists with prompts
 - [list-reduce](./list-reduce) - reduce lists prompts

--- a/src/verblets/README.md
+++ b/src/verblets/README.md
@@ -12,7 +12,7 @@ Available verblets:
 - [number-with-units](./number-with-units)
 - [sentiment](./sentiment) - classify text sentiment
 - [schema-org](./schema-org)
-- [name](./name) - suggest concise names for data
+- [name](./name) - name something from a definition or description
 - [to-object](./to-object) – see its [README](./to-object/README.md) for details.
 - [list-map](./list-map) - map lists with prompts
 - [list-reduce](./list-reduce) - reduce lists prompts

--- a/src/verblets/name/README.md
+++ b/src/verblets/name/README.md
@@ -1,0 +1,20 @@
+# name
+
+Generate a short, memorable name for any piece of data. The verblet asks an LLM to suggest a concise variable-style name.
+
+```javascript
+import name from './index.js';
+
+const datasetName = await name('A spreadsheet of every pastry I ate on my travels across Europe');
+// => 'travelPastryLog'
+```
+
+## Use case: sharing family stories
+
+Imagine scanning the handwritten letters your grandparents exchanged during the war. Instead of calling the folder `old_letters_scans`, let the verblet propose something warmer:
+
+```javascript
+const title = await name('Digital scans of my grandparents\' wartime letters');
+```
+
+Now you have a friendly label for a piece of personal history.

--- a/src/verblets/name/README.md
+++ b/src/verblets/name/README.md
@@ -1,20 +1,10 @@
 # name
 
-Generate a short, memorable name for any piece of data. The verblet asks an LLM to suggest a concise variable-style name.
+Generate a short, memorable name from a description of definition. The verblet asks an LLM to suggest a concise variable-style name.
 
 ```javascript
 import name from './index.js';
 
-const datasetName = await name('A spreadsheet of every pastry I ate on my travels across Europe');
+const foundName = await name('A spreadsheet of every pastry I ate on my travels across Europe');
 // => 'travelPastryLog'
 ```
-
-## Use case: sharing family stories
-
-Imagine scanning the handwritten letters your grandparents exchanged during the war. Instead of calling the folder `old_letters_scans`, let the verblet propose something warmer:
-
-```javascript
-const title = await name('Digital scans of my grandparents\' wartime letters');
-```
-
-Now you have a friendly label for a piece of personal history.

--- a/src/verblets/name/index.examples.js
+++ b/src/verblets/name/index.examples.js
@@ -4,7 +4,7 @@ import { longTestTimeout } from '../../constants/common.js';
 
 describe('name examples', () => {
   it(
-    'suggests dataset titles',
+    'suggests titles',
     async () => {
       const result = await name('Collection of recipes from my grandmother');
       expect(typeof result).toBe('string');

--- a/src/verblets/name/index.examples.js
+++ b/src/verblets/name/index.examples.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import name from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('name examples', () => {
+  it(
+    'suggests dataset titles',
+    async () => {
+      const result = await name('Collection of recipes from my grandmother');
+      expect(typeof result).toBe('string');
+    },
+    longTestTimeout
+  );
+});

--- a/src/verblets/name/index.js
+++ b/src/verblets/name/index.js
@@ -3,10 +3,9 @@ import wrapVariable from '../../prompts/wrap-variable.js';
 import stripResponse from '../../lib/strip-response/index.js';
 
 export default async function name(subject) {
-  const prompt = `Suggest a concise, memorable variable name for the <subject>.\n\n${wrapVariable(
-    subject,
-    { tag: 'subject' }
-  )}`;
+  const prompt = `Suggest a concise, memorable name for the <subject>.\n\n${wrapVariable(subject, {
+    tag: 'subject',
+  })}`;
   const response = await chatGPT(prompt);
   const [firstLine] = stripResponse(response).split('\n');
   return firstLine.trim();

--- a/src/verblets/name/index.js
+++ b/src/verblets/name/index.js
@@ -1,0 +1,13 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import wrapVariable from '../../prompts/wrap-variable.js';
+import stripResponse from '../../lib/strip-response/index.js';
+
+export default async function name(subject) {
+  const prompt = `Suggest a concise, memorable variable name for the <subject>.\n\n${wrapVariable(
+    subject,
+    { tag: 'subject' }
+  )}`;
+  const response = await chatGPT(prompt);
+  const [firstLine] = stripResponse(response).split('\n');
+  return firstLine.trim();
+}

--- a/src/verblets/name/index.spec.js
+++ b/src/verblets/name/index.spec.js
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+import name from './index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn().mockResolvedValue('travelSnacks'),
+}));
+
+describe('name verblet', () => {
+  it('suggests a short name', async () => {
+    const result = await name('List of snacks I tried while traveling');
+    expect(result).toBe('travelSnacks');
+  });
+});


### PR DESCRIPTION
## Summary
- create `name` verblet for generating short dataset names
- document `name` verblet with example and use case
- include tests and example files
- update exports and README listings

## Testing
- `npm run lint`
- `CI=true npm run test`

------
https://chatgpt.com/codex/tasks/task_b_684533a398748332bd83100040ee7162