### PR TITLE
Add coreference chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Content utilities generate, transform, and analyze text while maintaining struct
 
 - [anonymize](./src/chains/anonymize) - scrub personal details from text
 - [dismantle](./src/chains/dismantle) - break complex systems into components
+- [coreference](./src/chains/coreference) - resolve pronouns to their referenced entities
 - [list](./src/chains/list) - generate contextual lists from prompts
 - [questions](./src/chains/questions) - produce clarifying questions for topics
 - [schema-org](./src/verblets/schema-org) - create schema.org-compliant data structures

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -7,6 +7,7 @@ Available chains:
 - [anonymize](./anonymize)
 - [bulk-map](./bulk-map)
 - [dismantle](./dismantle)
+- [coreference](./coreference)
 - [list](./list)
 - [questions](./questions)
 - [scan-js](./scan-js)

--- a/src/chains/coreference/README.md
+++ b/src/chains/coreference/README.md
@@ -1,0 +1,21 @@
+# coreference
+
+Resolve what pronouns like "he", "she" or "it" refer to inside a passage of text.
+The chain walks backward through the text using a sliding window of nearby sentences
+so later clues can help clarify earlier references.
+
+```javascript
+import coreference from './index.js';
+
+const text = `Alice handed Bob her notebook. He thanked her and put it on the table.`;
+const result = await coreference(text);
+console.log(result);
+/*
+[
+  { pronoun: 'it', reference: 'the notebook', sentence: 'He thanked her and put it on the table.' },
+  { pronoun: 'her', reference: 'Alice', sentence: 'He thanked her and put it on the table.' },
+  { pronoun: 'he', reference: 'Bob', sentence: 'He thanked her and put it on the table.' },
+  { pronoun: 'her', reference: 'Alice', sentence: 'Alice handed Bob her notebook.' }
+]
+*/
+```

--- a/src/chains/coreference/index.examples.js
+++ b/src/chains/coreference/index.examples.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import coreference from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('coreference example', () => {
+  it(
+    'basic example',
+    async () => {
+      const text = 'Alice gave Bob her notebook. He thanked her for it.';
+      const result = await coreference(text);
+      expect(Array.isArray(result)).toBe(true);
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/coreference/index.js
+++ b/src/chains/coreference/index.js
@@ -1,0 +1,54 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import toObject from '../../verblets/to-object/index.js';
+import { constants as promptConstants } from '../../prompts/index.js';
+import modelService from '../../services/llm-model/index.js';
+
+const { onlyJSON } = promptConstants;
+
+export const extractSentences = (text) => {
+  const matches = text.match(/[^.!?]+[.!?]+/g);
+  if (!matches) {
+    return [text];
+  }
+  return matches.map((s) => s.trim());
+};
+
+export const extractPronouns = (sentence) => {
+  const pronounRegex =
+    /\b(he|she|they|it|him|her|them|his|hers|their|its|we|us|our|you|your|yours|i|me|my|mine|this|that|these|those)\b/gi;
+  const matches = sentence.match(pronounRegex) || [];
+  return [...new Set(matches.map((p) => p.toLowerCase()))];
+};
+
+const pronounPrompt = ({ context, sentence, pronoun }) => `
+${onlyJSON}
+Context:\n${context}
+
+In the sentence "${sentence}", what does the pronoun "${pronoun}" refer to? Respond with { "reference": "<short description>" }.
+${onlyJSON}`;
+
+export default async function coreference(
+  text,
+  { windowSize = 2, model = modelService.getBestPublicModel() } = {}
+) {
+  const sentences = extractSentences(text);
+  const results = [];
+  for (let i = sentences.length - 1; i >= 0; i -= 1) {
+    const sentence = sentences[i];
+    const pronouns = extractPronouns(sentence);
+    if (!pronouns.length) continue;
+    const start = Math.max(0, i - windowSize);
+    const end = Math.min(sentences.length, i + windowSize + 1);
+    const context = sentences.slice(start, end).join(' ');
+    for (const pronoun of pronouns) {
+      const prompt = pronounPrompt({ context, sentence, pronoun });
+      const budget = model.budgetTokens(prompt);
+      // eslint-disable-next-line no-await-in-loop
+      const response = await chatGPT(prompt, { maxTokens: budget.completion });
+      // eslint-disable-next-line no-await-in-loop
+      const { reference } = await toObject(response);
+      results.push({ pronoun, reference, sentence });
+    }
+  }
+  return results.reverse();
+}

--- a/src/chains/coreference/index.spec.js
+++ b/src/chains/coreference/index.spec.js
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+import coreference from './index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn().mockResolvedValue('{"reference":"John"}'),
+}));
+
+describe('coreference', () => {
+  it('resolves simple pronoun', async () => {
+    const text = 'John went home. He slept.';
+    const result = await coreference(text, { windowSize: 1 });
+    expect(result).toEqual([{ pronoun: 'he', reference: 'John', sentence: 'He slept.' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `coreference` chain to resolve pronoun references with a sliding window
- document new chain
- list `coreference` in chain catalogs

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_684534e87dc4833287070c2000651640