### PR TITLE
Add polysemy disambiguation chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Content utilities generate, transform, and analyze text while maintaining struct
 
 - [anonymize](./src/chains/anonymize) - scrub personal details from text
 - [dismantle](./src/chains/dismantle) - break complex systems into components
+- [disambiguate](./src/chains/disambiguate) - resolve ambiguous word meanings using context
 - [list](./src/chains/list) - generate contextual lists from prompts
 - [questions](./src/chains/questions) - produce clarifying questions for topics
 - [schema-org](./src/verblets/schema-org) - create schema.org-compliant data structures

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -7,6 +7,7 @@ Available chains:
 - [anonymize](./anonymize)
 - [bulk-map](./bulk-map)
 - [dismantle](./dismantle)
+- [disambiguate](./disambiguate)
 - [list](./list)
 - [questions](./questions)
 - [scan-js](./scan-js)

--- a/src/chains/disambiguate/README.md
+++ b/src/chains/disambiguate/README.md
@@ -1,0 +1,22 @@
+# disambiguate
+
+Determine the intended meaning of a polysemous word or short phrase based on surrounding context.
+The chain lists common meanings and filters them down to the one that fits best.
+
+```javascript
+import disambiguate from './index.js';
+
+const result = await disambiguate({
+  term: 'bat',
+  context: 'The child swung the bat at the baseball.'
+});
+
+console.log(result.meaning);
+// => "a club used in sports like baseball"
+```
+
+## Use case: clarifying travel conversations
+
+When a traveler says, "I spoke with the coach about my seat," it helps to know
+whether they mean a sports instructor or an airline seating class. This chain
+uses language model reasoning to resolve that ambiguity automatically.

--- a/src/chains/disambiguate/index.examples.js
+++ b/src/chains/disambiguate/index.examples.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import disambiguate from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('Disambiguate chain', () => {
+  it(
+    'contextual meaning: bank',
+    async () => {
+      const result = await disambiguate({
+        term: 'bank',
+        context: 'She waited in line at the bank to deposit her paycheck.',
+      });
+      expect(typeof result.meaning).toBe('string');
+      expect(result.meaning.length).toBeGreaterThan(0);
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/disambiguate/index.js
+++ b/src/chains/disambiguate/index.js
@@ -1,0 +1,33 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import listFilter from '../../verblets/list-filter/index.js';
+import toObject from '../../verblets/to-object/index.js';
+import { constants as promptConstants } from '../../prompts/index.js';
+import modelService from '../../services/llm-model/index.js';
+
+const { onlyJSONStringArray } = promptConstants;
+
+const meaningsPrompt = (term) => {
+  return `${onlyJSONStringArray}
+List all distinct dictionary meanings or common uses of "${term}".
+${onlyJSONStringArray}`;
+};
+
+export const getMeanings = async (term, { model = modelService.getBestPublicModel() } = {}) => {
+  const prompt = meaningsPrompt(term);
+  const budget = model.budgetTokens(prompt);
+  const response = await chatGPT(prompt, { maxTokens: budget.completion });
+  return toObject(response);
+};
+
+export default async function disambiguate({
+  term,
+  context,
+  model = modelService.getBestPublicModel(),
+} = {}) {
+  const meanings = await getMeanings(term, { model });
+  const best = await listFilter(
+    meanings,
+    `the meaning of "${term}" in context: ${context}. Keep only the single best matching meaning.`
+  );
+  return { meaning: best[0], meanings };
+}

--- a/src/chains/disambiguate/index.spec.js
+++ b/src/chains/disambiguate/index.spec.js
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import disambiguate from './index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn(async (prompt) => {
+    if (/List all distinct dictionary meanings/.test(prompt)) {
+      return '["financial institution","edge of a river"]';
+    }
+    return '[]';
+  }),
+}));
+
+vi.mock('../../verblets/list-filter/index.js', () => ({
+  default: vi.fn(async (list) => {
+    return [list[0]];
+  }),
+}));
+
+describe('disambiguate chain', () => {
+  it('selects meaning based on context', async () => {
+    const result = await disambiguate({ term: 'bank', context: 'withdraw money' });
+    expect(result.meaning).toBe('financial institution');
+    expect(result.meanings).toStrictEqual(['financial institution', 'edge of a river']);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `disambiguate` chain for contextual word sense resolution
- document chain in module README and list it in README files
- include example and unit test for the chain

## Testing
- `npm run lint`
- `npm run test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_684534b0012083329bc23b132f03b355