### PR TITLE
Add text-units chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Content utilities generate, transform, and analyze text while maintaining struct
 
 - [anonymize](./src/chains/anonymize) - scrub personal details from text
 - [dismantle](./src/chains/dismantle) - break complex systems into components
+- [text-units](./src/chains/text-units) - map sentences, paragraphs, and sections
 - [list](./src/chains/list) - generate contextual lists from prompts
 - [questions](./src/chains/questions) - produce clarifying questions for topics
 - [schema-org](./src/verblets/schema-org) - create schema.org-compliant data structures

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -7,6 +7,7 @@ Available chains:
 - [anonymize](./anonymize)
 - [bulk-map](./bulk-map)
 - [dismantle](./dismantle)
+- [text-units](./text-units)
 - [list](./list)
 - [questions](./questions)
 - [scan-js](./scan-js)

--- a/src/chains/text-units/README.md
+++ b/src/chains/text-units/README.md
@@ -1,0 +1,17 @@
+# text-units
+
+Identify visible units within any piece of text using an LLM. The chain detects sentences, paragraphs, sections, chapters—whatever structure is present—and returns their character offsets.
+
+```javascript
+import textUnits from './index.js';
+
+const diary = `Chapter 1\nI left home today. The air smelled like new beginnings.`;
+const units = await textUnits(diary);
+console.log(units);
+// => [ { type: 'chapter', start: 0, end: 9 },
+//      { type: 'sentence', start: 10, end: 34 },
+//      { type: 'sentence', start: 35, end: 66 },
+//      { type: 'paragraph', start: 10, end: 66 } ]
+```
+
+Imagine flipping through an old travel journal. With `text-units`, you can instantly map every heading, paragraph, and sentence to analyze how the story unfolds.

--- a/src/chains/text-units/index.js
+++ b/src/chains/text-units/index.js
@@ -1,0 +1,21 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import { constants as promptConstants } from '../../prompts/index.js';
+import wrapVariable from '../../prompts/wrap-variable.js';
+import modelService from '../../services/llm-model/index.js';
+import toObject from '../../verblets/to-object/index.js';
+
+const { onlyJSONObjectArray, contentIsDetails } = promptConstants;
+
+const unitsPrompt = (text) => `
+${onlyJSONObjectArray}
+Identify all visible units of the text such as sentences, paragraphs, sections or chapters. For each unit return an object { "type": "<unit name>", "start": <start index>, "end": <end index> }. Character offsets refer to the original text. Include nested or overlapping ranges if they exist.
+${contentIsDetails} ${wrapVariable(text)}
+${onlyJSONObjectArray}`;
+
+export default async (text, options = {}) => {
+  const { model = modelService.getBestPublicModel() } = options;
+  const prompt = unitsPrompt(text);
+  const budget = model.budgetTokens(prompt);
+  const response = await chatGPT(prompt, { maxTokens: budget.completion, ...options });
+  return toObject(response);
+};

--- a/src/chains/text-units/index.spec.js
+++ b/src/chains/text-units/index.spec.js
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from 'vitest';
+import textUnits from './index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn(async () => '[{"type":"sentence","start":0,"end":12}]'),
+}));
+
+describe('text-units chain', () => {
+  it('returns detected units', async () => {
+    const result = await textUnits('Hello world.');
+    expect(result).toStrictEqual([{ type: 'sentence', start: 0, end: 12 }]);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import chatGPT from './lib/chatgpt/index.js';
 import anonymize from './chains/anonymize/index.js';
 
 import Dismantle from './chains/dismantle/index.js';
+import textUnits from './chains/text-units/index.js';
 
 import list from './chains/list/index.js';
 
@@ -111,6 +112,7 @@ export const verblets = {
   bulkMap,
   anonymize,
   Dismantle,
+  textUnits,
   list,
   questions,
   scanJS,


### PR DESCRIPTION
## Summary
- add a new `text-units` chain that finds sentences, paragraphs, and sections
- document the new chain with a relatable example
- list it in chain README and root README
- export the chain from the library
- test the chain with mocked ChatGPT

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_684535115c148332b73c99b98d15886e