### PR TITLE
Improve themes chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Content utilities generate, transform, and analyze text while maintaining struct
 - [schema-org](./src/verblets/schema-org) - create schema.org-compliant data structures
 - [to-object](./src/verblets/to-object) - convert descriptions to structured objects
 - [veiled-variants](./src/chains/veiled-variants) - rephrase sensitive queries safely
+- [themes](./src/chains/themes) - uncover the big ideas in text and where each appears
 
 ### Utility Operations
 Utility operations provide meta-functionality like automatic tool selection, intent parsing, and context compression. They're essential for building intelligent systems that can adapt and scale.

--- a/src/chains/themes/README.md
+++ b/src/chains/themes/README.md
@@ -1,0 +1,20 @@
+# themes
+
+Reveal a text's key themes and map them back to the sentences where they appear. The chain first scans fragments in batches to collect possible themes, then runs a consolidation step to normalize and deduplicate them. Optionally it returns a per-sentence map showing which themes surface in each line.
+
+```javascript
+import themes from './index.js';
+
+const news = `The storm toppled trees and damaged homes. Volunteers quickly arrived with food and tools. Their kindness inspired hope throughout the town.`;
+
+const result = await themes(news, { sentenceMap: true });
+/* {
+ * themes: ['disaster recovery', 'community', 'hope'],
+ * sentenceThemes: [
+ *   [0, ['disaster recovery']],
+ *   [44, ['community']],
+ *   [114, ['hope']]
+ * ]
+ */
+```
+

--- a/src/chains/themes/index.examples.js
+++ b/src/chains/themes/index.examples.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import themes from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('themes chain', () => {
+  it(
+    'maps themes to sentences',
+    async () => {
+      const text = `When the rain finally stopped, neighbors emerged to help one another. They shared food and repaired homes, turning hardship into solidarity.`;
+      const result = await themes(text, { sentenceMap: true });
+      expect(Array.isArray(result.themes)).toBe(true);
+      expect(Array.isArray(result.sentenceThemes)).toBe(true);
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/themes/index.js
+++ b/src/chains/themes/index.js
@@ -1,0 +1,84 @@
+import bulkReduce from '../bulk-reduce/index.js';
+import listReduce from '../../verblets/list-reduce/index.js';
+
+/**
+ * Identify key themes from a long piece of text. The text is first split into
+ * fragments which are processed in batches with `bulkReduce` to gather initial
+ * theme candidates. The resulting list of themes is then condensed with a
+ * second `listReduce` call to produce a final concise set.
+ *
+ * @param {string} text - input text to analyze
+ * @param {object} [options]
+ * @param {number} [options.chunkSize=8] - how many fragments per batch
+ * @param {number} [options.maxThemes=5] - maximum number of final themes
+ * @returns {Promise<string[]>} array of short theme descriptions
+ */
+export default async function themes(
+  text,
+  { chunkSize = 8, maxThemes = 5, sentenceMap = false, explain = false } = {}
+) {
+  const fragments = text
+    .split(/\n{2,}|(?<=[.!?])\s+/)
+    .map((f) => f.trim())
+    .filter(Boolean);
+
+  const initialThemes = await bulkReduce(
+    fragments,
+    'Add high-level themes from each item to the accumulator as a comma separated list. Avoid duplicates.',
+    { chunkSize, initial: '' }
+  );
+
+  const themeCandidates = [
+    ...new Set(
+      initialThemes
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean)
+    ),
+  ];
+
+  const consolidated = await listReduce(
+    '',
+    themeCandidates,
+    `Consolidate and normalize these themes into a short, unique list separated by commas. Limit to about ${maxThemes} items.`
+  );
+
+  const themesList = consolidated
+    .split(',')
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean)
+    .slice(0, maxThemes);
+
+  let sentenceThemes;
+  if (sentenceMap) {
+    const sentences = [];
+    const regex = /[^.!?]+[.!?]+|[^.!?]+$/g;
+    let match;
+    while ((match = regex.exec(text))) {
+      const sentenceText = match[0].trim();
+      if (!sentenceText) continue;
+      sentences.push({ offset: match.index, sentenceText });
+    }
+
+    const mappingJson = await bulkReduce(
+      sentences,
+      `The accumulator is a JSON array. For each item provided as {offset, sentenceText},
+append [offset, themes] to the array where "themes" lists any of the following:
+${themesList.join(', ')}. Use an empty array if none apply.`,
+      { chunkSize, initial: '[]' }
+    );
+
+    sentenceThemes = JSON.parse(mappingJson);
+  }
+
+  if (sentenceMap || explain) {
+    const result = { themes: themesList };
+    if (sentenceMap) result.sentenceThemes = sentenceThemes;
+    if (explain) {
+      result.explanation = `Analyzed ${fragments.length} fragments to derive ${themesList.length} themes.`;
+    }
+    return result;
+  }
+
+  return themesList;
+}

--- a/src/chains/themes/index.spec.js
+++ b/src/chains/themes/index.spec.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import themes from './index.js';
+import bulkReduce from '../bulk-reduce/index.js';
+import listReduce from '../../verblets/list-reduce/index.js';
+
+vi.mock('../bulk-reduce/index.js', () => ({
+  default: vi.fn(async (list, instr, { initial }) => {
+    return Array.isArray(JSON.parse(initial || 'null')) ? JSON.stringify([[0, ['a']]]) : 'a, b';
+  }),
+}));
+
+vi.mock('../../verblets/list-reduce/index.js', () => ({
+  default: vi.fn(async () => 'a, b, c'),
+}));
+
+describe('themes chain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns array of themes', async () => {
+    const result = await themes('some text');
+    expect(result).toStrictEqual(['a', 'b', 'c']);
+    expect(bulkReduce).toHaveBeenCalled();
+    expect(listReduce).toHaveBeenCalled();
+  });
+
+  it('maps themes when sentenceMap true', async () => {
+    const result = await themes('some text', { sentenceMap: true });
+    expect(result).toStrictEqual({
+      themes: ['a', 'b', 'c'],
+      sentenceThemes: [[0, ['a']]],
+    });
+    expect(bulkReduce).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- document theme mapping in the README
- update module documentation with example of sentence mapping
- expand example and tests for sentenceMap option
- add consolidation step and optional sentence mapping in `themes` chain

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_6845352d27ac8332b7050b0cf4a17fa5