### PR TITLE
Add glossary chain for complex term extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@ This document explains the internal architecture and development practices for t
 
 ## Architecture Overview
 
-The verblets project has a clear three-tier architecture that separates concerns and enables composable AI-powered functionality:
+The verblets project has two main types of components:
 
-### 1. **Chains** (`src/chains/`)
+### **Chains** (`src/chains/`)
 LLM orchestrations that combine multiple verblets, other chains, and library utilities to perform complex workflows. Chains handle multi-step reasoning, batch processing, and sophisticated AI operations.
 
 **Examples:**
@@ -21,8 +21,8 @@ LLM orchestrations that combine multiple verblets, other chains, and library uti
 - Often include retry logic and error handling
 - May process data in chunks or batches
 
-### 2. **Verblets** (`src/verblets/`)
-Single-call LLM functions with substantial, carefully crafted prompts. Each verblet performs one specific AI task with high reliability and constrained outputs.
+### **Verblets** (`src/verblets/`)
+Single LLM calls with carefully crafted prompts and prompt-supporting functions. Each verblet performs one specific AI task with high reliability and constrained outputs.
 
 **Examples:**
 - `bool` - Extract true/false decisions from natural language
@@ -32,18 +32,19 @@ Single-call LLM functions with substantial, carefully crafted prompts. Each verb
 
 **Characteristics:**
 - Single LLM call per operation
-- Substantial, optimized prompts
+- Substantial, optimized prompts with prompt variables
 - Constrained outputs to prevent hallucination
 - High reliability for specific tasks
 
-### 3. **Library Utilities** (`src/lib/`)
-Supporting utilities that don't use LLMs directly. These include API wrappers, data processing functions, caching, and other infrastructure.
+### **Library Utilities** (`src/lib/`)
+Supporting utilities that don't use LLMs directly. These provide infrastructure, data processing, and reusable functions that support both chains and verblets.
 
 **Examples:**
 - `chatgpt` - OpenAI API wrapper with error handling
 - `prompt-cache` - Caching layer for LLM responses
 - `retry` - Robust retry logic for async operations
 - `parse-js-parts` - JavaScript AST parsing utilities
+- `parse-llm-list` - Parse JSON arrays or CSV from LLM responses with filtering
 
 **Characteristics:**
 - No direct LLM usage

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Content utilities generate, transform, and analyze text while maintaining struct
 - [list](./src/chains/list) - generate contextual lists from prompts
 - [questions](./src/chains/questions) - produce clarifying questions for topics
 - [socratic](./src/chains/socratic) - explore assumptions using a Socratic dialogue
+- [glossary](./src/chains/glossary) - collect complex terms with automatic retries
 - [schema-org](./src/verblets/schema-org) - create schema.org-compliant data structures
 - [name](./src/verblets/name) - name something from a definition or description
 - [to-object](./src/verblets/to-object) - convert descriptions to structured objects

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "chai": "^4.3.7",
         "change-case": "^4.1.2",
         "commander": "^11.0.0",
+        "compromise": "^14.14.4",
         "dependency-tree": "^10.0.1",
         "dotenv": "^16.0.3",
         "gpt-tokenizer": "^2.1.2",
@@ -3114,6 +3115,20 @@
         "node": ">=16"
       }
     },
+    "node_modules/compromise": {
+      "version": "14.14.4",
+      "resolved": "https://registry.npmjs.org/compromise/-/compromise-14.14.4.tgz",
+      "integrity": "sha512-QdbJwronwxeqb7a5KFK/+Y5YieZ4PE1f7ai0vU58Pp4jih+soDCBMuKVbhDEPQ+6+vI3vSiG4UAAjTAXLJw1Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "efrt": "2.7.0",
+        "grad-school": "0.0.5",
+        "suffix-thumb": "5.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/comver-to-semver": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/comver-to-semver/-/comver-to-semver-1.0.0.tgz",
@@ -3583,6 +3598,15 @@
       "version": "0.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/efrt": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/efrt/-/efrt-2.7.0.tgz",
+      "integrity": "sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.162",
@@ -5244,6 +5268,15 @@
       },
       "engines": {
         "node": ">=18.12"
+      }
+    },
+    "node_modules/grad-school": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/grad-school/-/grad-school-0.0.5.tgz",
+      "integrity": "sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -9310,6 +9343,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/suffix-thumb": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/suffix-thumb/-/suffix-thumb-5.0.2.tgz",
+      "integrity": "sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "chai": "^4.3.7",
     "change-case": "^4.1.2",
     "commander": "^11.0.0",
+    "compromise": "^14.14.4",
     "dependency-tree": "^10.0.1",
     "dotenv": "^16.0.3",
     "gpt-tokenizer": "^2.1.2",

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -14,6 +14,7 @@ Available chains:
 - [list](./list)
 - [questions](./questions)
 - [socratic](./socratic)
+- [glossary](./glossary)
 - [scan-js](./scan-js)
 - [sort](./sort)
 - [summary-map](./summary-map)

--- a/src/chains/glossary/README.md
+++ b/src/chains/glossary/README.md
@@ -1,0 +1,19 @@
+# glossary
+
+Identify difficult or technical terms in any text so you can explain them later.
+The chain breaks long passages into paragraphs and uses the `bulk-map` retry
+utility to collect candidate terms from each chunk. Any failed paragraphs are
+automatically retried. Finally the terms are ranked by importance using `sort`.
+
+```javascript
+import glossary from './index.js';
+
+const blog = `The chef explained how umami develops through the Maillard reaction alongside sous-vide techniques.`;
+
+const terms = await glossary(blog, { maxTerms: 3 });
+console.log(terms);
+// => ['Maillard reaction', 'sous-vide', 'umami']
+```
+
+This is handy when you want to add a quick glossary sidebar to a dense article
+so everyday readers aren't left guessing what key terms mean.

--- a/src/chains/glossary/index.examples.js
+++ b/src/chains/glossary/index.examples.js
@@ -1,14 +1,466 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import glossary from './index.js';
+import { expect as llmExpect } from '../../chains/llm-expect/index.js';
 import { longTestTimeout } from '../../constants/common.js';
 
 describe('glossary examples', () => {
+  // Set environment mode to 'none' for all tests to avoid throwing
+  const originalMode = process.env.LLM_EXPECT_MODE;
+
+  beforeAll(() => {
+    process.env.LLM_EXPECT_MODE = 'none';
+  });
+
+  afterAll(() => {
+    if (originalMode !== undefined) {
+      process.env.LLM_EXPECT_MODE = originalMode;
+    } else {
+      delete process.env.LLM_EXPECT_MODE;
+    }
+  });
+
   it(
     'extracts terms from a science paragraph',
     async () => {
       const text = `The chef explained how umami develops through the Maillard reaction alongside sous-vide techniques.`;
       const result = await glossary(text, { maxTerms: 2 });
+
       expect(result.length).toBeGreaterThan(0);
+      expect(Array.isArray(result)).toBe(true);
+
+      // LLM assertion to validate that extracted terms are technical/complex
+      const [areTermsTechnical] = await llmExpect(
+        `From the text "${text}", these terms were extracted: ${result.join(', ')}`,
+        undefined,
+        'Are these terms technical or complex enough that a casual reader might need definitions?',
+        {
+          errorText: `Expected extracted terms to be technical/complex, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        areTermsTechnical,
+        `Expected extracted terms to be technical/complex, but got: ${result.join(', ')}`
+      ).toBe(true);
+
+      // LLM assertion to validate terms are relevant to the source text
+      const [areTermsRelevant] = await llmExpect(
+        `Original text: "${text}" | Extracted terms: ${result.join(', ')}`,
+        undefined,
+        'Are all these extracted terms actually present or directly related to the original text?',
+        {
+          errorText: `Expected terms to be relevant to source text, but extracted: ${result.join(
+            ', '
+          )} from: "${text}"`,
+        }
+      );
+      expect(
+        areTermsRelevant,
+        `Expected terms to be relevant to source text, but extracted: ${result.join(
+          ', '
+        )} from: "${text}"`
+      ).toBe(true);
+
+      // LLM assertion to validate term selection quality
+      const [isGoodSelection] = await llmExpect(
+        `For a cooking/culinary text, these terms were selected for a glossary: ${result.join(
+          ', '
+        )}`,
+        undefined,
+        'Are these appropriate terms for a culinary glossary that would help readers understand cooking concepts?',
+        { errorText: `Expected appropriate culinary terms, but got: ${result.join(', ')}` }
+      );
+      expect(
+        isGoodSelection,
+        `Expected appropriate culinary terms, but got: ${result.join(', ')}`
+      ).toBe(true);
+    },
+    longTestTimeout
+  );
+
+  it(
+    'handles technical documentation with multiple complex terms',
+    async () => {
+      const text = `The microservice architecture implements OAuth 2.0 authentication with JWT tokens, 
+      utilizing Redis for session management and PostgreSQL for persistent data storage. 
+      The API gateway handles load balancing through consistent hashing algorithms.`;
+
+      const result = await glossary(text, { maxTerms: 5 });
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBeLessThanOrEqual(5);
+
+      // LLM assertion for technical term appropriateness
+      const [areTechTermsAppropriate] = await llmExpect(
+        `From technical documentation, these terms were extracted: ${result.join(', ')}`,
+        undefined,
+        'Are these terms technical enough that a non-developer would need explanations?',
+        {
+          errorText: `Expected technical terms appropriate for non-developers, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        areTechTermsAppropriate,
+        `Expected technical terms appropriate for non-developers, but got: ${result.join(', ')}`
+      ).toBe(true);
+
+      // LLM assertion for term diversity and coverage
+      const [goodCoverage] = await llmExpect(
+        `Original text covers microservices, authentication, databases, and algorithms. Extracted terms: ${result.join(
+          ', '
+        )}`,
+        undefined,
+        'Do these extracted terms represent a good variety of the technical concepts mentioned?',
+        {
+          errorText: `Expected good coverage of technical concepts, but extracted terms: ${result.join(
+            ', '
+          )} may not cover the variety in the source text`,
+        }
+      );
+      expect(
+        goodCoverage,
+        `Expected good coverage of technical concepts, but extracted terms: ${result.join(
+          ', '
+        )} may not cover the variety in the source text`
+      ).toBe(true);
+
+      // LLM assertion for ranking quality
+      const [wellRanked] = await llmExpect(
+        `Terms extracted in this order: ${result.join(' → ')}`,
+        undefined,
+        'Does this ranking make reasonable sense for a technical glossary? Consider that architectural concepts often come before specific tools, and authentication concepts before databases. The ranking should help readers understand concepts in a logical progression.',
+        {
+          errorText: `Expected reasonable ranking for technical glossary, but got order: ${result.join(
+            ' → '
+          )}. Consider whether this helps readers understand concepts progressively.`,
+        }
+      );
+      expect(
+        wellRanked,
+        `Expected reasonable ranking for technical glossary, but got order: ${result.join(
+          ' → '
+        )}. Consider whether this helps readers understand concepts progressively.`
+      ).toBe(true);
+    },
+    longTestTimeout
+  );
+
+  it(
+    'filters out common words and focuses on specialized terms',
+    async () => {
+      const text = `The quantum entanglement phenomenon occurs when particles become interconnected, 
+      demonstrating superposition states that challenge classical physics understanding. 
+      This behavior is fundamental to quantum computing applications.`;
+
+      const result = await glossary(text, { maxTerms: 4 });
+
+      expect(result.length).toBeGreaterThan(0);
+
+      // LLM assertion to ensure no common words are included
+      const [noCommonWords] = await llmExpect(
+        `These terms were selected for a glossary: ${result.join(', ')}`,
+        undefined,
+        'Are all of these terms specialized/technical rather than common everyday words?',
+        {
+          errorText: `Expected only specialized/technical terms, but some may be common words: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        noCommonWords,
+        `Expected only specialized/technical terms, but some may be common words: ${result.join(
+          ', '
+        )}`
+      ).toBe(true);
+
+      // LLM assertion for scientific accuracy
+      const [scientificallyAccurate] = await llmExpect(
+        `From a quantum physics text, these terms were extracted: ${result.join(', ')}`,
+        undefined,
+        'Are these reasonable terms that relate to quantum physics or scientific concepts? They should be legitimate scientific terminology, even if not all are highly technical quantum physics terms.',
+        {
+          errorText: `Expected reasonable scientific terms related to quantum physics, but got: ${result.join(
+            ', '
+          )}. Terms should be legitimate scientific concepts.`,
+        }
+      );
+      expect(
+        scientificallyAccurate,
+        `Expected reasonable scientific terms related to quantum physics, but got: ${result.join(
+          ', '
+        )}. Terms should be legitimate scientific concepts.`
+      ).toBe(true);
+
+      // LLM assertion for educational value
+      const [educationalValue] = await llmExpect(
+        `For someone learning about quantum physics, these glossary terms were provided: ${result.join(
+          ', '
+        )}`,
+        undefined,
+        'Would defining these terms be helpful for understanding the quantum physics concepts in the text? Focus on whether they contribute to comprehension rather than requiring perfect technical precision.',
+        {
+          errorText: `Expected terms that would help with understanding quantum physics concepts, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        educationalValue,
+        `Expected terms that would help with understanding quantum physics concepts, but got: ${result.join(
+          ', '
+        )}`
+      ).toBe(true);
+    },
+    longTestTimeout
+  );
+
+  it(
+    'handles empty or simple text appropriately',
+    async () => {
+      const simpleText = `The cat sat on the mat. It was a sunny day.`;
+      const result = await glossary(simpleText, { maxTerms: 3 });
+
+      // Should return empty array or very few terms for simple text
+      expect(Array.isArray(result)).toBe(true);
+
+      if (result.length > 0) {
+        // If any terms are returned, they should still be reasonable
+        const [reasonableForSimpleText] = await llmExpect(
+          `From simple text "${simpleText}", these terms were extracted: ${result.join(', ')}`,
+          undefined,
+          'If any terms were extracted from this simple text, are they reasonable choices?',
+          {
+            errorText: `Expected reasonable terms for simple text, but extracted: ${result.join(
+              ', '
+            )} from: "${simpleText}"`,
+          }
+        );
+        expect(
+          reasonableForSimpleText,
+          `Expected reasonable terms for simple text, but extracted: ${result.join(
+            ', '
+          )} from: "${simpleText}"`
+        ).toBe(true);
+      } else {
+        // LLM assertion that empty result is appropriate for simple text
+        const [appropriatelyEmpty] = await llmExpect(
+          `For the simple text "${simpleText}", no glossary terms were extracted`,
+          undefined,
+          'Is it appropriate to extract no glossary terms from this simple, everyday text?',
+          { errorText: `Expected empty result to be appropriate for simple text: "${simpleText}"` }
+        );
+        expect(
+          appropriatelyEmpty,
+          `Expected empty result to be appropriate for simple text: "${simpleText}"`
+        ).toBe(true);
+      }
+    },
+    longTestTimeout
+  );
+
+  it(
+    'extracts operative philosophical terms for conceptual clarity',
+    async () => {
+      const philosophyText = `Heidegger's concept of Dasein fundamentally challenges the Cartesian subject-object distinction 
+      through his analysis of Being-in-the-world. The phenomenological reduction, as developed by Husserl, 
+      brackets the natural attitude to reveal the intentional structure of consciousness. This hermeneutic circle 
+      demonstrates how our pre-understanding shapes interpretation, while the ontological difference between 
+      beings and Being itself remains concealed in everyday thrownness. Gadamer's fusion of horizons extends 
+      this analysis to show how tradition and prejudice constitute the productive ground of understanding.`;
+
+      const result = await glossary(philosophyText, { maxTerms: 8 });
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBeLessThanOrEqual(8);
+
+      // LLM assertion for philosophical term appropriateness - abstract concepts
+      const [arePhilosophicalConcepts] = await llmExpect(
+        `From philosophical text, these terms were extracted: ${result.join(', ')}`,
+        undefined,
+        'Are these terms abstract philosophical concepts, technical phenomenological terms, or fundamental ontological categories that require precise definition for understanding?',
+        {
+          errorText: `Expected abstract philosophical concepts requiring definition, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        arePhilosophicalConcepts,
+        `Expected abstract philosophical concepts requiring definition, but got: ${result.join(
+          ', '
+        )}`
+      ).toBe(true);
+
+      // LLM assertion for conceptual precision - terms that need clarification
+      const [needDefinition] = await llmExpect(
+        `These philosophical terms: ${result.join(', ')}`,
+        undefined,
+        'Are these terms that would genuinely benefit from precise definition to avoid misunderstanding or ambiguity in philosophical discourse?',
+        {
+          errorText: `Expected terms needing precise definition for clarity, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        needDefinition,
+        `Expected terms needing precise definition for clarity, but got: ${result.join(', ')}`
+      ).toBe(true);
+
+      // LLM assertion for operative significance - terms central to the argument
+      const [operativeTerms] = await llmExpect(
+        `In the context of phenomenology and hermeneutics, these terms were selected: ${result.join(
+          ', '
+        )}`,
+        undefined,
+        'Are these terms operatively significant - meaning they carry specific technical weight and are central to understanding the philosophical arguments being made?',
+        {
+          errorText: `Expected operatively significant philosophical terms, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        operativeTerms,
+        `Expected operatively significant philosophical terms, but got: ${result.join(', ')}`
+      ).toBe(true);
+
+      // LLM assertion for avoiding common words - focus on technical terminology
+      const [avoidCommonPhilosophical] = await llmExpect(
+        `These terms from philosophical text: ${result.join(', ')}`,
+        undefined,
+        'Are these specialized philosophical terms rather than common words that happen to appear in philosophical contexts?',
+        {
+          errorText: `Expected specialized philosophical terms, not common words, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        avoidCommonPhilosophical,
+        `Expected specialized philosophical terms, not common words, but got: ${result.join(', ')}`
+      ).toBe(true);
+    },
+    longTestTimeout
+  );
+
+  it(
+    'extracts operative tech terms across multiple categories',
+    async () => {
+      const techText = `The team implemented Domain-Driven Design using the Repository pattern and CQRS architecture. 
+      Martin Fowler's Strangler Fig pattern helped migrate the legacy system while Kent Beck's Test-Driven Development 
+      approach ensured code quality. We used Docker containers orchestrated by Kubernetes, with Redis for caching 
+      and PostgreSQL for persistence. The CI/CD pipeline leveraged Jenkins and implemented the Blue-Green deployment 
+      strategy. Uncle Bob's Clean Architecture principles guided the service boundaries, while Eric Evans' 
+      Bounded Context concept helped define microservice boundaries. The team followed Scrum methodology with 
+      pair programming sessions.`;
+
+      const result = await glossary(techText, {
+        maxTerms: 12,
+        sortBy:
+          'importance for understanding the content, prioritizing concrete tools and technologies (Docker, Kubernetes, Redis, PostgreSQL, Jenkins) equally with architectural patterns and methodologies',
+      });
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBeLessThanOrEqual(12);
+
+      // LLM assertion for technical tools identification
+      const [includesTools] = await llmExpect(
+        `From tech text, these terms were extracted: ${result.join(', ')}`,
+        undefined,
+        'Do these terms include technical tools, technologies, or software systems (like Docker, Kubernetes, Redis, PostgreSQL, Jenkins)?',
+        {
+          errorText: `Expected to include technical tools/technologies, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        includesTools,
+        `Expected to include technical tools/technologies, but got: ${result.join(', ')}`
+      ).toBe(true);
+
+      // LLM assertion for design patterns identification
+      const [includesPatterns] = await llmExpect(
+        `These terms from software development: ${result.join(', ')}`,
+        undefined,
+        'Do these terms include software design patterns, architectural patterns, or development patterns (like Repository, CQRS, Strangler Fig, Blue-Green)?',
+        {
+          errorText: `Expected to include design/architectural patterns, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        includesPatterns,
+        `Expected to include design/architectural patterns, but got: ${result.join(', ')}`
+      ).toBe(true);
+
+      // LLM assertion for methodologies and practices
+      const [includesMethodologies] = await llmExpect(
+        `From development context, these terms: ${result.join(', ')}`,
+        undefined,
+        'Do these terms include software development methodologies, practices, or approaches (like Domain-Driven Design, Test-Driven Development, Clean Architecture, Scrum)?',
+        {
+          errorText: `Expected to include development methodologies/practices, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        includesMethodologies,
+        `Expected to include development methodologies/practices, but got: ${result.join(', ')}`
+      ).toBe(true);
+
+      // LLM assertion for key people/thought leaders (optional but valuable)
+      const [mayIncludePeople] = await llmExpect(
+        `These tech terms: ${result.join(', ')}`,
+        undefined,
+        'Do these terms appropriately focus on concepts, tools, and patterns rather than just including person names, while potentially including key thought leaders if they are central to understanding specific methodologies?',
+        {
+          errorText: `Expected focus on concepts/tools over person names, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        mayIncludePeople,
+        `Expected focus on concepts/tools over person names, but got: ${result.join(', ')}`
+      ).toBe(true);
+
+      // LLM assertion for operative significance in tech context
+      const [operativeTechTerms] = await llmExpect(
+        `In a software development context, these terms: ${result.join(', ')}`,
+        undefined,
+        'Are these terms operatively significant for understanding the technical architecture, development practices, and implementation decisions being described?',
+        { errorText: `Expected operatively significant tech terms, but got: ${result.join(', ')}` }
+      );
+      expect(
+        operativeTechTerms,
+        `Expected operatively significant tech terms, but got: ${result.join(', ')}`
+      ).toBe(true);
+
+      // LLM assertion for practical utility - terms that need definition
+      const [practicalUtility] = await llmExpect(
+        `For someone learning about software architecture and development, these terms: ${result.join(
+          ', '
+        )}`,
+        undefined,
+        'Are these terms that would genuinely benefit from clear definitions to understand modern software development practices and architectural decisions?',
+        {
+          errorText: `Expected terms needing definition for learning, but got: ${result.join(
+            ', '
+          )}`,
+        }
+      );
+      expect(
+        practicalUtility,
+        `Expected terms needing definition for learning, but got: ${result.join(', ')}`
+      ).toBe(true);
     },
     longTestTimeout
   );

--- a/src/chains/glossary/index.examples.js
+++ b/src/chains/glossary/index.examples.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import glossary from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('glossary examples', () => {
+  it(
+    'extracts terms from a science paragraph',
+    async () => {
+      const text = `The chef explained how umami develops through the Maillard reaction alongside sous-vide techniques.`;
+      const result = await glossary(text, { maxTerms: 2 });
+      expect(result.length).toBeGreaterThan(0);
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/glossary/index.js
+++ b/src/chains/glossary/index.js
@@ -1,39 +1,75 @@
+import nlp from 'compromise';
 import sort from '../sort/index.js';
 import { bulkMapRetry } from '../bulk-map/index.js';
+import { constants as promptConstants } from '../../prompts/index.js';
+import parseLLMList from '../../lib/parse-llm-list/index.js';
+
+const { onlyJSONStringArrayPerLine } = promptConstants;
 
 /**
- * Extract uncommon or technical terms from text so they can be defined later.
- * Large texts are processed paragraph by paragraph and the terms are
- * de-duplicated then ranked by importance.
+ * Extract uncommon or technical terms from text that would benefit from definition.
  *
  * @param {string} text - source text
  * @param {object} [options]
  * @param {number} [options.maxTerms=10] - maximum terms to return
- * @returns {Promise<string[]>} ordered list of important terms
+ * @param {number} [options.batchSize=3] - number of sentences per batch
+ * @param {number} [options.overlap=1] - number of overlapping sentences between batches
+ * @param {number} [options.chunkSize=1] - number of text chunks to process in parallel
+ * @param {string} [options.sortBy='importance for understanding the content'] - sorting criteria
+ * @returns {Promise<string[]>} list of important terms, sorted by relevance
  */
-export default async function glossary(text, { maxTerms = 10, chunkSize = 5 } = {}) {
-  const paragraphs = text.split(/\n{2,}/).filter((p) => p.trim() !== '');
-  const instructions =
-    'List the complex or technical terms a casual reader might not understand from <item>. ' +
-    'Return them comma separated on a single line.';
+export default async function glossary(
+  text,
+  {
+    maxTerms = 10,
+    batchSize = 3,
+    overlap = 1,
+    chunkSize = 1,
+    sortBy = 'importance for understanding the content',
+  } = {}
+) {
+  if (!text || !text.trim()) return [];
 
-  const mapped = await bulkMapRetry(paragraphs, instructions, { chunkSize });
+  // Parse sentences using compromise
+  const doc = nlp(text);
+  const sentences = doc.sentences().out('array');
+
+  if (sentences.length === 0) return [];
+
+  // Create batches of sentences with overlap
+  const textChunks = [];
+  for (let i = 0; i < sentences.length; i += batchSize - overlap) {
+    const batch = sentences.slice(i, i + batchSize);
+    if (batch.length > 0) {
+      textChunks.push(batch.join(' '));
+    }
+  }
+
+  const instructions = `For each text chunk, extract specialized terms that would benefit from definition in a glossary.
+
+Focus on terms that:
+- Are technical, academic, or domain-specific
+- Would be unfamiliar to a general audience  
+- Carry precise meaning in their field
+- Are essential for understanding the content
+
+${onlyJSONStringArrayPerLine}`;
+
+  const mapped = await bulkMapRetry(textChunks, instructions, { chunkSize });
 
   const termSet = new Set();
   mapped.forEach((line) => {
-    if (typeof line === 'string') {
-      line
-        .split(',')
-        .map((t) => t.trim())
-        .filter(Boolean)
-        .forEach((t) => termSet.add(t));
-    }
+    const terms = parseLLMList(line);
+    terms.forEach((term) => {
+      termSet.add(term);
+    });
   });
 
-  const ranked = await sort(
-    { by: 'by importance and difficulty for general audiences' },
-    Array.from(termSet)
-  );
+  const terms = Array.from(termSet);
+  if (terms.length === 0) return [];
 
-  return ranked.slice(0, maxTerms);
+  // Sort by importance for understanding the content
+  const sorted = await sort({ by: sortBy }, terms);
+
+  return sorted.slice(0, maxTerms);
 }

--- a/src/chains/glossary/index.js
+++ b/src/chains/glossary/index.js
@@ -1,0 +1,39 @@
+import sort from '../sort/index.js';
+import { bulkMapRetry } from '../bulk-map/index.js';
+
+/**
+ * Extract uncommon or technical terms from text so they can be defined later.
+ * Large texts are processed paragraph by paragraph and the terms are
+ * de-duplicated then ranked by importance.
+ *
+ * @param {string} text - source text
+ * @param {object} [options]
+ * @param {number} [options.maxTerms=10] - maximum terms to return
+ * @returns {Promise<string[]>} ordered list of important terms
+ */
+export default async function glossary(text, { maxTerms = 10, chunkSize = 5 } = {}) {
+  const paragraphs = text.split(/\n{2,}/).filter((p) => p.trim() !== '');
+  const instructions =
+    'List the complex or technical terms a casual reader might not understand from <item>. ' +
+    'Return them comma separated on a single line.';
+
+  const mapped = await bulkMapRetry(paragraphs, instructions, { chunkSize });
+
+  const termSet = new Set();
+  mapped.forEach((line) => {
+    if (typeof line === 'string') {
+      line
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean)
+        .forEach((t) => termSet.add(t));
+    }
+  });
+
+  const ranked = await sort(
+    { by: 'by importance and difficulty for general audiences' },
+    Array.from(termSet)
+  );
+
+  return ranked.slice(0, maxTerms);
+}

--- a/src/chains/glossary/index.spec.js
+++ b/src/chains/glossary/index.spec.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import glossary from './index.js';
+
+vi.mock('../bulk-map/index.js', () => ({
+  bulkMapRetry: vi.fn(() => Promise.resolve(['qubits, entanglement', 'decoherence, qubits'])),
+  default: vi.fn(),
+}));
+
+vi.mock('../sort/index.js', () => ({
+  default: vi.fn((opts, list) => Promise.resolve(list)),
+}));
+
+describe('glossary', () => {
+  it('collects unique terms', async () => {
+    const text = 'para1\n\npara2';
+    const result = await glossary(text, { maxTerms: 5 });
+    expect(result).toStrictEqual(['qubits', 'entanglement', 'decoherence']);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import Dismantle from './chains/dismantle/index.js';
 import intersections from './chains/intersections/index.js';
 
 import list from './chains/list/index.js';
+import glossary from './chains/glossary/index.js';
 
 import questions from './chains/questions/index.js';
 
@@ -130,6 +131,7 @@ export const verblets = {
   Dismantle,
   intersections,
   list,
+  glossary,
   questions,
   SocraticMethod,
   scanJS,

--- a/src/lib/parse-llm-list/README.md
+++ b/src/lib/parse-llm-list/README.md
@@ -1,0 +1,39 @@
+# Parse LLM List
+
+A utility function for parsing lists from LLM responses that may be in JSON array or CSV format.
+
+## Usage
+
+```javascript
+import parseLLMList from './src/lib/parse-llm-list/index.js';
+
+// Parse JSON array response
+const jsonResponse = '["term1", "term2", "term3"]';
+const terms1 = parseLLMList(jsonResponse);
+// Returns: ["term1", "term2", "term3"]
+
+// Parse CSV response
+const csvResponse = 'term1, term2, term3';
+const terms2 = parseLLMList(csvResponse);
+// Returns: ["term1", "term2", "term3"]
+
+// With custom options
+const terms3 = parseLLMList(response, {
+  excludeValues: ['none', 'null', 'n/a'],
+  trimItems: true,
+  filterEmpty: true
+});
+```
+
+## Options
+
+- `excludeValues` (string[]): Values to exclude from results (case-insensitive). Default: `['none', 'null', 'undefined']`
+- `trimItems` (boolean): Whether to trim whitespace from items. Default: `true`
+- `filterEmpty` (boolean): Whether to filter out empty strings. Default: `true`
+
+## Features
+
+- Automatically detects JSON array vs CSV format
+- Handles common LLM response patterns like `<note>` tags
+- Filters out excluded values and empty responses
+- Robust error handling with fallback parsing 

--- a/src/lib/parse-llm-list/index.js
+++ b/src/lib/parse-llm-list/index.js
@@ -1,0 +1,54 @@
+/**
+ * Parse a list of items from LLM response that could be JSON array or CSV format.
+ * Handles common LLM response patterns and filters out invalid entries.
+ *
+ * @param {string} response - The LLM response string
+ * @param {object} [options] - Parsing options
+ * @param {string[]} [options.excludeValues=['none', 'null', 'undefined']] - Values to exclude (case-insensitive)
+ * @param {boolean} [options.trimItems=true] - Whether to trim whitespace from items
+ * @param {boolean} [options.filterEmpty=true] - Whether to filter out empty strings
+ * @returns {string[]} Array of parsed items
+ */
+export default function parseLLMList(
+  response,
+  { excludeValues = ['none', 'null', 'undefined'], trimItems = true, filterEmpty = true } = {}
+) {
+  if (!response || typeof response !== 'string') {
+    return [];
+  }
+
+  // Skip responses that contain notes or are empty arrays
+  if (response === '[]' || response.includes('<note>')) {
+    return [];
+  }
+
+  const items = [];
+
+  try {
+    // First try to parse as JSON array
+    const parsed = JSON.parse(response);
+    if (Array.isArray(parsed)) {
+      items.push(...parsed.filter((item) => typeof item === 'string'));
+    }
+  } catch {
+    // Fallback to comma-separated parsing if JSON fails
+    items.push(...response.split(','));
+  }
+
+  // Process the items
+  let processedItems = items;
+
+  if (trimItems) {
+    processedItems = processedItems.map((item) => item.trim());
+  }
+
+  if (filterEmpty) {
+    processedItems = processedItems.filter(Boolean);
+  }
+
+  // Filter out excluded values (case-insensitive)
+  const excludeSet = new Set(excludeValues.map((val) => val.toLowerCase()));
+  processedItems = processedItems.filter((item) => !excludeSet.has(item.toLowerCase()));
+
+  return processedItems;
+}

--- a/src/lib/parse-llm-list/index.spec.js
+++ b/src/lib/parse-llm-list/index.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import parseLLMList from './index.js';
+
+describe('parseLLMList', () => {
+  it('parses JSON array format', () => {
+    const input = '["term1", "term2", "term3"]';
+    const result = parseLLMList(input);
+    expect(result).toEqual(['term1', 'term2', 'term3']);
+  });
+
+  it('parses CSV format', () => {
+    const input = 'term1, term2, term3';
+    const result = parseLLMList(input);
+    expect(result).toEqual(['term1', 'term2', 'term3']);
+  });
+
+  it('handles empty array response', () => {
+    const input = '[]';
+    const result = parseLLMList(input);
+    expect(result).toEqual([]);
+  });
+
+  it('handles responses with notes', () => {
+    const input = '<note>No terms found</note>';
+    const result = parseLLMList(input);
+    expect(result).toEqual([]);
+  });
+
+  it('filters out excluded values', () => {
+    const input = 'term1, none, term2, null, term3';
+    const result = parseLLMList(input);
+    expect(result).toEqual(['term1', 'term2', 'term3']);
+  });
+
+  it('trims whitespace from items', () => {
+    const input = '  term1  ,  term2  ,  term3  ';
+    const result = parseLLMList(input);
+    expect(result).toEqual(['term1', 'term2', 'term3']);
+  });
+
+  it('filters out empty strings', () => {
+    const input = 'term1, , term2, , term3';
+    const result = parseLLMList(input);
+    expect(result).toEqual(['term1', 'term2', 'term3']);
+  });
+
+  it('handles custom exclude values', () => {
+    const input = 'term1, n/a, term2, unknown, term3';
+    const result = parseLLMList(input, { excludeValues: ['n/a', 'unknown'] });
+    expect(result).toEqual(['term1', 'term2', 'term3']);
+  });
+
+  it('handles invalid input gracefully', () => {
+    expect(parseLLMList(null)).toEqual([]);
+    expect(parseLLMList(undefined)).toEqual([]);
+    expect(parseLLMList('')).toEqual([]);
+    expect(parseLLMList(123)).toEqual([]);
+  });
+});

--- a/src/prompts/constants.js
+++ b/src/prompts/constants.js
@@ -19,6 +19,8 @@ const onlyJSONArrayBase =
   'Respond with a JSON array that parses with JSON.parse, with no additional text, no punctuation, and no code block.';
 export const onlyJSONArray = onlyJSONArrayBase;
 export const onlyJSONStringArray = `${onlyJSONArrayBase} The array should only contain text. No additional structure.`;
+export const onlyJSONStringArrayPerLine =
+  'For each input line, return exactly one line containing a JSON array of strings. No additional text, no code blocks.';
 export const onlyJSONObjectArray =
   'Return an array of obects--not strings, and not just the objects.';
 export const onlyJSONStringArrayAlt1 = 'Output an JSON array of strings.';

--- a/src/verblets/list-map/index.js
+++ b/src/verblets/list-map/index.js
@@ -9,7 +9,10 @@ const buildPrompt = function (list, instructions) {
 
 export default async function listMap(list, instructions) {
   const output = await chatGPT(buildPrompt(list, instructions));
-  const lines = output.split('\n');
+  const lines = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
   if (lines.length !== list.length) {
     throw new Error(
       `Batch output line count mismatch (expected ${list.length}, got ${lines.length})`


### PR DESCRIPTION
## Summary
- add `glossary` chain to collect technical terms
- document chain and example usage
- update chain index and exports
- list glossary chain in root README and chains README

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_6845358776248332a62dcec4fe19d4aa