### PR TITLE
Add configurable logger and batch logger chain

### DIFF
--- a/src/chains/list/index.js
+++ b/src/chains/list/index.js
@@ -7,6 +7,7 @@ import {
 } from '../../prompts/index.js';
 import modelService from '../../services/llm-model/index.js';
 import toObject from '../../verblets/to-object/index.js';
+import logger from '../../lib/logger/index.js';
 
 const { onlyJSON, contentIsTransformationSource } = promptConstants;
 
@@ -62,18 +63,18 @@ export const generateList = async function* generateListGenerator(text, options 
       });
 
       // debug helper:
-      // console.error(R.sort((a, b) => a.localeCompare(b), await toObject(results)));
+      // logger.error(R.sort((a, b) => a.localeCompare(b), await toObject(results)));
 
       // eslint-disable-next-line no-await-in-loop
       resultsNew = await toObject(results);
     } catch (error) {
       if (/The operation was aborted/.test(error.message)) {
         // eslint-disable-next-line no-console
-        console.error('Generate list [error]: Aborted');
+        logger.error('Generate list [error]: Aborted');
         resultsNew = []; // continue
       } else {
         // eslint-disable-next-line no-console
-        console.error(
+        logger.error(
           `Generate list [error]: ${error.message}`,
           listPrompt.slice(0, 100).replace('\n', '\\n')
         );
@@ -107,7 +108,7 @@ export const generateList = async function* generateListGenerator(text, options 
         resultsAll.push(result);
 
         // debug helper:
-        // console.error(R.sort((a, b) => a.localeCompare(b), resultsAll));
+        // logger.error(R.sort((a, b) => a.localeCompare(b), resultsAll));
 
         yield result;
       }

--- a/src/chains/logger/README.md
+++ b/src/chains/logger/README.md
@@ -1,0 +1,10 @@
+# logger
+
+Batch log messages and emit them using a provided logger.
+
+```javascript
+import createLogger from '../../index.js';
+
+const logger = createLogger({ batchSize: 5, flushInterval: 5000 });
+logger.info('hello');
+```

--- a/src/chains/logger/index.js
+++ b/src/chains/logger/index.js
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+
+const bulkMap = async (list, fn, chunkSize = 10) => {
+  const results = new Array(list.length);
+  const promises = [];
+  for (let i = 0; i < list.length; i += chunkSize) {
+    const batch = list.slice(i, i + chunkSize);
+    const startIndex = i;
+    const p = Promise.resolve()
+      .then(() => Promise.all(batch.map(fn)))
+      .then((output) => {
+        output.forEach((r, j) => {
+          results[startIndex + j] = r;
+        });
+      });
+    promises.push(p);
+  }
+  await Promise.all(promises);
+  return results;
+};
+
+const formatLog = ({ level, args, stack }) => {
+  const stackLine = stack.split('\n')[2] || '';
+  const match = stackLine.match(/\((.*):(\d+):(\d+)\)/);
+  let context = '';
+  if (match) {
+    const [, file, line] = match;
+    try {
+      const lines = fs.readFileSync(file, 'utf8').split('\n');
+      const codeLine = lines[Number(line) - 1]?.trim();
+      context = `${file}:${line} ${codeLine}`;
+    } catch {
+      /* ignore */
+    }
+  }
+  const parts = args.map((a) => {
+    if (a instanceof Error) {
+      return `${a.message}\n${a.stack}`;
+    }
+    if (typeof a === 'object') {
+      try {
+        return JSON.stringify(a);
+      } catch {
+        return String(a);
+      }
+    }
+    return String(a);
+  });
+  return { level, message: `[${level}] ${context} ${parts.join(' ')}` };
+};
+
+export default function createLogger({
+  batchSize = 10,
+  flushInterval = 5000,
+  baseLogger = console,
+} = {}) {
+  let logs = [];
+  let timer;
+
+  const flush = async () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (!logs.length) return;
+    const batch = logs;
+    logs = [];
+    const formatted = await bulkMap(batch, formatLog, batchSize);
+    formatted.forEach(({ level, message }) => {
+      baseLogger[level](message);
+    });
+  };
+
+  const schedule = () => {
+    if (!timer) {
+      timer = setTimeout(flush, flushInterval);
+    }
+  };
+
+  const makeLog =
+    (level) =>
+    (...args) => {
+      logs.push({ level, args, stack: new Error().stack });
+      if (logs.length >= batchSize) {
+        flush();
+      } else {
+        schedule();
+      }
+    };
+
+  return {
+    info: makeLog('info'),
+    debug: makeLog('debug'),
+    warn: makeLog('warn'),
+    error: makeLog('error'),
+    flush,
+  };
+}

--- a/src/chains/logger/index.spec.js
+++ b/src/chains/logger/index.spec.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import createLogger from './index.js';
+
+describe('logger chain', () => {
+  it('flushes after batch size reached', async () => {
+    const base = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const logger = createLogger({ batchSize: 10, flushInterval: 5000, baseLogger: base });
+    logger.info('a');
+    logger.info('b');
+    await logger.flush();
+    expect(base.info).toHaveBeenCalledTimes(2);
+  });
+
+  it('flushes after timeout', async () => {
+    vi.useFakeTimers();
+    const base = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const logger = createLogger({ batchSize: 10, flushInterval: 1000, baseLogger: base });
+    logger.info('a');
+    vi.advanceTimersByTime(1000);
+    await vi.runAllTimersAsync();
+    expect(base.info).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/src/chains/scan-js/index.js
+++ b/src/chains/scan-js/index.js
@@ -3,6 +3,7 @@ import * as R from 'ramda';
 
 import sort from '../sort/index.js';
 import chatGPT from '../../lib/chatgpt/index.js';
+import logger from '../../lib/logger/index.js';
 import pathAliases from '../../lib/path-aliases/index.js';
 import retry from '../../lib/retry/index.js';
 import search from '../../lib/search-js-files/index.js';
@@ -83,7 +84,7 @@ const visit = async ({
 
     const idDisplay = (state.pathAliases[id] ?? id).slice(-50).padStart(50);
 
-    console.error(
+    logger.error(
       `${`${state.nodesFound}`.padEnd(3, ' ')} ${idDisplay}: ${organizeResult(resultParsed).join(
         ', '
       )}`

--- a/src/chains/veiled-variants/index.js
+++ b/src/chains/veiled-variants/index.js
@@ -1,5 +1,6 @@
 import { run } from '../../lib/chatgpt/index.js';
 import { constants as promptConstants, wrapVariable } from '../../prompts/index.js';
+import logger from '../../lib/logger/index.js';
 
 const { onlyJSONStringArray } = promptConstants;
 
@@ -97,7 +98,7 @@ const veiledVariants = async ({ prompt, modelName = 'privacy' }) => {
         }
 
         // Fallback: return the raw response as a single item
-        console.warn('Failed to parse JSON response, using raw text:', error.message);
+        logger.warn('Failed to parse JSON response, using raw text:', error.message);
         return [trimmed];
       }
     })

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ import scanJS from './chains/scan-js/index.js';
 import sort from './chains/sort/index.js';
 
 import SummaryMap from './chains/summary-map/index.js';
+import createBufferedLogger from './chains/logger/index.js';
 
 import test from './chains/test/index.js';
 
@@ -143,6 +144,7 @@ export const verblets = {
   bulkFilter,
   listGroup,
   intersection,
+  createBufferedLogger,
 };
 
 export const services = {

--- a/src/lib/chatgpt/index.js
+++ b/src/lib/chatgpt/index.js
@@ -12,6 +12,7 @@ import { get as getPromptResult, set as setPromptResult } from '../prompt-cache/
 import TimedAbortController from '../timed-abort-controller/index.js';
 import modelService from '../../services/llm-model/index.js';
 import { getClient as getRedis } from '../../services/redis/index.js';
+import logger from '../logger/index.js';
 
 const shapeOutputDefault = (result) => {
   // GPT-4
@@ -31,17 +32,17 @@ const shapeOutputDefault = (result) => {
 
 const onBeforeRequestDefault = ({ debugPrompt, isCached, prompt }) => {
   if (debugPrompt || debugPromptGlobally || (debugPromptGloballyIfChanged && !isCached)) {
-    console.error('+++ DEBUG PROMPT +++');
-    console.error(prompt);
-    console.error('+++ DEBUG PROMPT END +++');
+    logger.error('+++ DEBUG PROMPT +++');
+    logger.error(prompt);
+    logger.error('+++ DEBUG PROMPT END +++');
   }
 };
 
 const onAfterRequestDefault = ({ debugResult, isCached, resultShaped }) => {
   if (debugResult || debugResultGlobally || (debugResultGloballyIfChanged && !isCached)) {
-    console.error('+++ DEBUG RESULT +++');
-    console.error(resultShaped);
-    console.error('+++ DEBUG RESULT END +++');
+    logger.error('+++ DEBUG RESULT +++');
+    logger.error(resultShaped);
+    logger.error('+++ DEBUG RESULT END +++');
   }
 };
 

--- a/src/lib/logger/index.js
+++ b/src/lib/logger/index.js
@@ -1,0 +1,26 @@
+let currentLogger = {
+  info: (...args) => console.info(...args),
+  debug: (...args) => console.debug(...args),
+  warn: (...args) => console.warn(...args),
+  error: (...args) => console.error(...args),
+};
+
+export const setLogger = (logger) => {
+  if (logger && ['info', 'debug', 'warn', 'error'].every((m) => typeof logger[m] === 'function')) {
+    currentLogger = logger;
+  } else {
+    throw new Error('Logger must implement info, debug, warn and error methods');
+  }
+};
+
+export const getLogger = () => currentLogger;
+
+const proxy = {};
+['info', 'debug', 'warn', 'error'].forEach((level) => {
+  proxy[level] = (...args) => currentLogger[level](...args);
+});
+
+proxy.setLogger = setLogger;
+proxy.getLogger = getLogger;
+
+export default proxy;

--- a/src/lib/retry/index.js
+++ b/src/lib/retry/index.js
@@ -2,6 +2,7 @@ import {
   maxRetries as maxRetriesDefault,
   retryDelay as retryDelayDefault,
 } from '../../constants/common.js';
+import logger from '../logger/index.js';
 
 export default async (
   fn,
@@ -29,7 +30,7 @@ export default async (
         const startTag = `${retry > 0 ? 'retry' : 'started'}`;
         const startVariablesDisplay = `${retry > 0 ? ` (${variables})` : ''}`;
         // eslint-disable-next-line no-console
-        console.error(`Run ${labelDisplay} [${startTag}]${startVariablesDisplay}`);
+        logger.error(`Run ${labelDisplay} [${startTag}]${startVariablesDisplay}`);
       }
 
       // eslint-disable-next-line no-await-in-loop
@@ -37,7 +38,7 @@ export default async (
 
       if (label) {
         // eslint-disable-next-line no-console
-        console.error(`Run ${labelDisplay} [complete]`);
+        logger.error(`Run ${labelDisplay} [complete]`);
       }
 
       return result;
@@ -57,7 +58,7 @@ export default async (
 
       if (label) {
         // eslint-disable-next-line no-console
-        console.error(`Run ${labelDisplay} [${doneTag}]: ${error.message}`);
+        logger.error(`Run ${labelDisplay} [${doneTag}]: ${error.message}`);
       }
     }
   }

--- a/src/lib/search-js-files/index.js
+++ b/src/lib/search-js-files/index.js
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import parseJSParts from '../parse-js-parts/index.js';
 import search from '../search-best-first/index.js';
+import logger from '../logger/index.js';
 
 export class Node {
   constructor(args) {
@@ -45,7 +46,7 @@ const processNpmImport = async (source, includeNodeModules = false) => {
       }));
     }
   } catch (error) {
-    console.error(`Process npm import [error]: ${error.message} (source: ${source})`);
+    logger.error(`Process npm import [error]: ${error.message} (source: ${source})`);
   }
 
   return [];
@@ -53,7 +54,7 @@ const processNpmImport = async (source, includeNodeModules = false) => {
 
 const visitDefault = ({ state }) => {
   if (process.env.NODE_ENV === 'development') {
-    // console.error(`Visiting: ${node.filename} - ${node.functionName}`);
+    // logger.error(`Visiting: ${node.filename} - ${node.functionName}`);
   }
   return state;
 };

--- a/src/lib/transcribe/index.js
+++ b/src/lib/transcribe/index.js
@@ -1,5 +1,6 @@
 import whisper from 'whisper-node';
 import record from 'node-record-lpcm16';
+import logger from '../logger/index.js';
 
 export default class Transcriber {
   constructor(targetWord, silenceDuration = 5000, wordPauseDuration = 2000) {
@@ -36,7 +37,7 @@ export default class Transcriber {
         this.handleTranscription(transcription);
       })
       .catch((error) => {
-        console.error(error);
+        logger.error(error);
       });
   }
 

--- a/src/services/redis/index.js
+++ b/src/services/redis/index.js
@@ -1,4 +1,5 @@
 import { createClient } from 'redis';
+import logger from '../../lib/logger/index.js';
 
 let client;
 let constructingClient;
@@ -37,7 +38,7 @@ class SafeRedisClient {
       return await this.redisClient.get(key);
     } catch (error) {
       if (this.isConnectionError(error)) {
-        console.warn('Redis connection lost, falling back to in-memory cache');
+        logger.warn('Redis connection lost, falling back to in-memory cache');
         return this.fallbackClient.get(key);
       }
       throw error;
@@ -49,7 +50,7 @@ class SafeRedisClient {
       return await this.redisClient.set(key, value, options);
     } catch (error) {
       if (this.isConnectionError(error)) {
-        console.warn('Redis connection lost, falling back to in-memory cache');
+        logger.warn('Redis connection lost, falling back to in-memory cache');
         return this.fallbackClient.set(key, value, options);
       }
       throw error;
@@ -61,7 +62,7 @@ class SafeRedisClient {
       return await this.redisClient.del(key);
     } catch (error) {
       if (this.isConnectionError(error)) {
-        console.warn('Redis connection lost, falling back to in-memory cache');
+        logger.warn('Redis connection lost, falling back to in-memory cache');
         return this.fallbackClient.del(key);
       }
       throw error;
@@ -103,12 +104,12 @@ const constructClient = async () => {
     }
 
     if (/ECONNREFUSED/.test(error.message)) {
-      console.error(
+      logger.error(
         `Redis service [warning]: "${error.message}" Falling back to mock Redis client. This may incur greater usage costs and have slower response times.`
       );
       client = new NullRedisClient();
     } else {
-      console.error(`Redis service [error]: ${error.message}`);
+      logger.error(`Redis service [error]: ${error.message}`);
       client = new NullRedisClient();
     }
 
@@ -122,7 +123,7 @@ const constructClient = async () => {
     await redisClient.connect();
     client = new SafeRedisClient(redisClient);
   } catch (error) {
-    console.error(
+    logger.error(
       `Redis service create [warning]: "${error.message}" Falling back to mock Redis client. This may incur greater usage costs and have slower response times.`
     );
     client = new NullRedisClient();

--- a/src/verblets/list-group/index.js
+++ b/src/verblets/list-group/index.js
@@ -1,5 +1,6 @@
 import chatGPT from '../../lib/chatgpt/index.js';
 import wrapVariable from '../../prompts/wrap-variable.js';
+import logger from '../../lib/logger/index.js';
 
 const buildPrompt = (list, instructions, categories) => {
   const instructionsBlock = wrapVariable(instructions, { tag: 'instructions' });
@@ -32,7 +33,7 @@ export default async function listGroup(list, instructions, categories) {
   const labels = allLines.slice(0, list.length);
 
   if (labels.length !== list.length) {
-    console.warn(`Expected ${list.length} labels, got ${labels.length}. Output was:`, output);
+    logger.warn(`Expected ${list.length} labels, got ${labels.length}. Output was:`, output);
     // Pad with default category if we have fewer labels
     while (labels.length < list.length) {
       labels.push('other');

--- a/src/verblets/to-object/index.js
+++ b/src/verblets/to-object/index.js
@@ -5,6 +5,7 @@ import { retryJSONParse } from '../../constants/messages.js';
 import chatGPT from '../../lib/chatgpt/index.js';
 import stripResponse from '../../lib/strip-response/index.js';
 import { constants as promptConstants, wrapVariable } from '../../prompts/index.js';
+import logger from '../../lib/logger/index.js';
 
 const { contentIsSchema, contentToJSON, onlyJSON, shapeAsJSON } = promptConstants;
 
@@ -64,14 +65,14 @@ export default async (text, schema) => {
   } catch (error) {
     errorDetails = error.details;
     if (debugToObject) {
-      console.error(`Parse JSON [error]: ${error.message} ${retryJSONParse}`);
-      console.error('<prompt attempt=1 value="unknown" />');
-      console.error('<response>');
-      console.error(stripResponse(response));
-      console.error('</response>');
-      console.error('<error>');
-      console.error(error);
-      console.error('</error>');
+      logger.error(`Parse JSON [error]: ${error.message} ${retryJSONParse}`);
+      logger.error('<prompt attempt=1 value="unknown" />');
+      logger.error('<response>');
+      logger.error(stripResponse(response));
+      logger.error('</response>');
+      logger.error('<error>');
+      logger.error(error);
+      logger.error('</error>');
     }
   }
 
@@ -97,16 +98,16 @@ export default async (text, schema) => {
   } catch (error) {
     errorDetails = error.details;
     if (debugToObject) {
-      console.error(`Parse JSON [error]: ${error.message} ${retryJSONParse}`);
-      console.error('<prompt attempt=2>');
-      console.error(prompt);
-      console.error('</prompt>');
-      console.error('<response>');
-      console.error(stripResponse(response));
-      console.error('</response>');
-      console.error('<error>');
-      console.error(error);
-      console.error('</error>');
+      logger.error(`Parse JSON [error]: ${error.message} ${retryJSONParse}`);
+      logger.error('<prompt attempt=2>');
+      logger.error(prompt);
+      logger.error('</prompt>');
+      logger.error('<response>');
+      logger.error(stripResponse(response));
+      logger.error('</response>');
+      logger.error('<error>');
+      logger.error(error);
+      logger.error('</error>');
     }
 
     prompt = buildJsonPrompt(response, schema, errorDetails);
@@ -118,13 +119,13 @@ export default async (text, schema) => {
     result = JSON.parse(stripResponse(response));
 
     if (debugToObject) {
-      console.error(`Parse JSON [error]: ${error.message} ${retryJSONParse}`);
-      console.error('<prompt attempt=3>');
-      console.error(prompt);
-      console.error('</prompt>');
-      console.error('<response>');
-      console.error(stripResponse(response));
-      console.error('</response>');
+      logger.error(`Parse JSON [error]: ${error.message} ${retryJSONParse}`);
+      logger.error('<prompt attempt=3>');
+      logger.error(prompt);
+      logger.error('</prompt>');
+      logger.error('<response>');
+      logger.error(stripResponse(response));
+      logger.error('</response>');
     }
   }
 


### PR DESCRIPTION
## Summary
- provide `setLogger` utility to replace console logging
- use logger across codebase
- add buffered logger chain for batch emission
- export `createBufferedLogger` from package
- test the logger chain

## Testing
- `CI=true npm run test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6846565def50833299a86c9f5006917c