### PR TITLE
Add expectation-based date chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Primitive verblets extract basic data types from natural language with high reli
 - [enum](./src/verblets/enum) - map text to predefined options
 - [number](./src/verblets/number) - extract numeric values from text
 - [number-with-units](./src/verblets/number-with-units) - parse numbers with units and conversions
+- [date](./src/chains/date) - return Date objects from natural language prompts
 
 ### Lists
 
@@ -91,6 +92,7 @@ Codebase utilities analyze, test, and improve code quality using AI reasoning. T
 - [to-enum](./src/lib/to-enum) - parse text to enum values
 - [to-number](./src/lib/to-number) - parse text to numbers
 - [to-number-with-units](./src/lib/to-number-with-units) - parse numbers with units
+- [to-date](./src/lib/to-date) - parse text to JavaScript Date objects
 - [transcribe](./src/lib/transcribe) - microphone transcription via Whisper
 
 ## Example: Intelligent Customer Support System

--- a/src/chains/date/README.md
+++ b/src/chains/date/README.md
@@ -1,0 +1,12 @@
+# date
+
+Iteratively refine LLM answers until they produce a valid JavaScript `Date` object that satisfies the prompt. Before asking for a date, the chain asks the language model to suggest a few quick checks that a correct answer should satisfy. Each returned date is evaluated against those expectations with the `bool` verblt and retried if any fail.
+
+```javascript
+import date from './index.js';
+
+const release = await date('When was the original Star Wars film released?');
+// => new Date('1977-05-25')
+```
+
+The chain asks for a date using prompt constants shared with primitive verblets. It then verifies the result with the `bool` verblet and retries until the date is deemed correct or attempts run out.

--- a/src/chains/date/index.examples.js
+++ b/src/chains/date/index.examples.js
@@ -1,0 +1,47 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import date from './index.js';
+import { expect as llmExpect } from '../llm-expect/index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('date examples', () => {
+  const originalMode = process.env.LLM_EXPECT_MODE;
+
+  beforeAll(() => {
+    process.env.LLM_EXPECT_MODE = 'none';
+  });
+
+  afterAll(() => {
+    if (originalMode !== undefined) {
+      process.env.LLM_EXPECT_MODE = originalMode;
+    } else {
+      delete process.env.LLM_EXPECT_MODE;
+    }
+  });
+
+  it(
+    'gets Star Wars release date',
+    async () => {
+      const result = await date('When was the original Star Wars released?');
+      expect(result instanceof Date).toBe(true);
+      const [reasonable] = await llmExpect(
+        `Star Wars release date: ${result.toISOString()}`,
+        undefined,
+        'Is this close to the actual release date of the first Star Wars movie?'
+      );
+      expect(reasonable).toBe(true);
+    },
+    longTestTimeout
+  );
+
+  it(
+    'finds Christmas 2025',
+    async () => {
+      const result = await date('What day is Christmas in 2025?');
+      expect(result instanceof Date).toBe(true);
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(11); // December
+      expect(result.getDate()).toBe(25);
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/date/index.js
+++ b/src/chains/date/index.js
@@ -1,0 +1,58 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import stripResponse from '../../lib/strip-response/index.js';
+import toDate from '../../lib/to-date/index.js';
+import bool from '../../verblets/bool/index.js';
+import toObject from '../../verblets/to-object/index.js';
+import { constants as promptConstants } from '../../prompts/index.js';
+
+const {
+  asDate,
+  asUndefinedByDefault,
+  contentIsQuestion,
+  explainAndSeparate,
+  explainAndSeparatePrimitive,
+  onlyJSONArray,
+} = promptConstants;
+
+const expectationPrompt = (question) => `${contentIsQuestion} ${question}
+
+List up to three short yes/no checks that would confirm a date answer is correct. If nothing specific comes to mind, respond with ["The result is a valid date"].
+
+${onlyJSONArray}`;
+
+const buildCheckPrompt = (dateValue, check) => {
+  const iso = dateValue.toISOString();
+  const human = dateValue.toUTCString();
+  return `Date in ISO: ${iso} (UTC: ${human}). Does this satisfy "${check}"?`;
+};
+
+export default async function date(text, { maxAttempts = 3 } = {}) {
+  const expectations = (await toObject(await chatGPT(expectationPrompt(text)))) || [
+    'The result is a valid date',
+  ];
+
+  let attemptText = text;
+  let response;
+  for (let i = 0; i < maxAttempts; i += 1) {
+    const datePrompt = `${contentIsQuestion} ${attemptText}\n\n${explainAndSeparate} ${explainAndSeparatePrimitive}\n\n${asDate} ${asUndefinedByDefault}`;
+    // eslint-disable-next-line no-await-in-loop
+    response = await chatGPT(datePrompt);
+    const value = toDate(stripResponse(response));
+    if (value === undefined) return undefined;
+
+    let failedCheck;
+    for (const check of expectations) {
+      // eslint-disable-next-line no-await-in-loop
+      const passed = await bool(buildCheckPrompt(value, check));
+      if (!passed) {
+        failedCheck = check;
+        break;
+      }
+    }
+
+    if (!failedCheck) return value;
+
+    attemptText = `${text} The previous answer (${value.toISOString()}) failed to satisfy: "${failedCheck}". Try again.`;
+  }
+  return toDate(stripResponse(response));
+}

--- a/src/chains/date/index.spec.js
+++ b/src/chains/date/index.spec.js
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import date from './index.js';
+import bool from '../../verblets/bool/index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../../verblets/bool/index.js', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../../verblets/to-object/index.js', () => ({
+  default: vi.fn(),
+}));
+
+const chatGPT = (await import('../../lib/chatgpt/index.js')).default;
+const toObjectMock = (await import('../../verblets/to-object/index.js')).default;
+
+describe('date chain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it('returns a date when bool approves', async () => {
+    chatGPT.mockResolvedValueOnce('["check"]');
+    toObjectMock.mockResolvedValueOnce(['check']);
+    chatGPT.mockResolvedValueOnce('2023-01-02');
+    bool.mockResolvedValueOnce(true);
+    const result = await date('When is tomorrow?');
+    expect(result instanceof Date).toBe(true);
+    expect(result.toISOString().startsWith('2023-01-02')).toBe(true);
+    expect(chatGPT).toHaveBeenCalledTimes(2);
+    expect(toObjectMock).toHaveBeenCalledTimes(1);
+    expect(bool).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries until bool approves', async () => {
+    chatGPT.mockResolvedValueOnce('["check"]');
+    toObjectMock.mockResolvedValueOnce(['check']);
+    chatGPT.mockResolvedValueOnce('2023-01-02');
+    chatGPT.mockResolvedValueOnce('2023-02-03');
+    bool.mockResolvedValueOnce(false);
+    bool.mockResolvedValueOnce(true);
+
+    const result = await date('When is tomorrow?', { maxAttempts: 2 });
+    expect(result.toISOString().startsWith('2023-02-03')).toBe(true);
+    expect(chatGPT).toHaveBeenCalledTimes(3);
+    expect(toObjectMock).toHaveBeenCalledTimes(1);
+    expect(bool).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns undefined when chatGPT says undefined', async () => {
+    chatGPT.mockResolvedValueOnce('["check"]');
+    toObjectMock.mockResolvedValueOnce(['check']);
+    chatGPT.mockResolvedValueOnce('undefined');
+    const result = await date('Unknown date');
+    expect(result).toBeUndefined();
+    expect(chatGPT).toHaveBeenCalledTimes(2);
+    expect(toObjectMock).toHaveBeenCalledTimes(1);
+    expect(bool).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import SocraticMethod from './chains/socratic/index.js';
 import scanJS from './chains/scan-js/index.js';
 
 import sort from './chains/sort/index.js';
+import date from './chains/date/index.js';
 
 import SummaryMap from './chains/summary-map/index.js';
 
@@ -50,6 +51,7 @@ import toBool from './lib/to-bool/index.js';
 import toEnum from './lib/to-enum/index.js';
 import toNumber from './lib/to-number/index.js';
 import toNumberWithUnits from './lib/to-number-with-units/index.js';
+import toDate from './lib/to-date/index.js';
 import transcribe from './lib/transcribe/index.js';
 import combinations, { rangeCombinations } from './lib/combinations/index.js';
 
@@ -109,6 +111,7 @@ export const lib = {
   toEnum,
   toNumber,
   toNumberWithUnits,
+  toDate,
   transcribe,
   combinations,
   rangeCombinations,
@@ -138,6 +141,7 @@ export const verblets = {
   SocraticMethod,
   scanJS,
   sort,
+  date,
   SummaryMap,
   test,
   testAdvice,

--- a/src/lib/to-date/index.js
+++ b/src/lib/to-date/index.js
@@ -1,0 +1,11 @@
+import stripResponse from '../strip-response/index.js';
+
+export default (val) => {
+  const clean = stripResponse(String(val)).trim();
+  if (clean.toLowerCase() === 'undefined') return undefined;
+  const parsed = new Date(clean);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('ChatGPT output [error]');
+  }
+  return parsed;
+};

--- a/src/prompts/constants.js
+++ b/src/prompts/constants.js
@@ -3,6 +3,8 @@ export const asUndefinedByDefault = 'If you are unsure, say "undefined" as your 
 export const asBool = 'Answer the question either with "true" or "false" as your answer.';
 export const asNumber =
   'Answer the question with a number that could be parsed by the JS Number constructor. Do not include formatting, units, digit group separators, or spelled-out numbers in your answer.';
+export const asDate =
+  'Answer the question with a date that can be parsed by the JS Date constructor. ISO format is preferred. Do not include additional text or punctuation.';
 export const asJSON =
   'Respond with a JSON object or array that parses with JSON.parse, with no wrapping code block, and no wrapping XML.';
 

--- a/src/verblets/README.md
+++ b/src/verblets/README.md
@@ -10,6 +10,7 @@ Available verblets:
 - [intent](./intent)
 - [number](./number)
 - [number-with-units](./number-with-units)
+- [date](../chains/date)
 - [sentiment](./sentiment) - classify text sentiment
 - [schema-org](./schema-org)
 - [name-similar-to](./name-similar-to) - suggest short names matching a style


### PR DESCRIPTION
## Summary
- refine `date` chain to generate and check expectations
- document the new verification workflow
- update tests for expectation logic

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_684a46fff3ac833296fe604854c437a5