### PR TITLE
Refine setInterval chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Utility operations provide meta-functionality like automatic tool selection, int
 - [intent](./src/verblets/intent) - extract user intent and structured parameters
 - [sentiment](./src/verblets/sentiment) - detect emotional tone of text
 - [summary-map](./src/chains/summary-map) - store self-resizing hash table values. Useful for fixed-sized contexts.
+- [set-interval](./src/chains/set-interval) - Conversational scheduler
 
 ### Codebase
 

--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -19,6 +19,7 @@ Available chains:
 - [scan-js](./scan-js)
 - [sort](./sort)
 - [summary-map](./summary-map)
+- [set-interval](./set-interval)
 - [test](./test)
 - [test-advice](./test-advice)
 - [veiled-variants](./veiled-variants)

--- a/src/chains/set-interval/README.md
+++ b/src/chains/set-interval/README.md
@@ -1,0 +1,16 @@
+# setInterval
+
+AI-guided replacement for `setInterval`.
+Feed it your own natural-language heuristic; it will keep time, remember history, and supply your callback with rich context so you can build self-tuning workflows, creative generators, or living UIs.
+
+```javascript
+setInterval({
+  intervalPrompt: String,   // mandatory
+  fn:            Function,  // mandatory
+  historySize?:  Number,
+  firstInterval?:String,
+  model?:        String,
+}); // returns a cancel function
+```
+
+Return data from `fn` becomes `lastInvocationResult` in the subsequent prompt, enabling reducer-like evolution.

--- a/src/chains/set-interval/index.examples.js
+++ b/src/chains/set-interval/index.examples.js
@@ -1,0 +1,33 @@
+import { describe, it } from 'vitest';
+import setInterval from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('setInterval (example)', () => {
+  it(
+    'adjusts meditation sessions using wearable stress levels',
+    async () => {
+      const stop = setInterval({
+        intervalPrompt:
+          'Start at 3 min. If lastInvocationResult.stress > 70, shorten by 1 min; if below 30, lengthen by 2 min.',
+        fn: () => {},
+      });
+      await new Promise((r) => setTimeout(r, 5000));
+      stop();
+    },
+    longTestTimeout
+  );
+
+  it(
+    'paces game events to match player skill',
+    async () => {
+      const stop = setInterval({
+        intervalPrompt:
+          'Begin at 10 sec. If lastInvocationResult.winRate > 80, decrease by 2 sec; if under 40, increase by 5 sec.',
+        fn: () => {},
+      });
+      await new Promise((r) => setTimeout(r, 5000));
+      stop();
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/set-interval/index.js
+++ b/src/chains/set-interval/index.js
@@ -1,0 +1,110 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import numberWithUnits from '../../verblets/number-with-units/index.js';
+import number from '../../verblets/number/index.js';
+import date from '../date/index.js';
+import { constants as promptConstants } from '../../prompts/index.js';
+
+const { contentIsInstructions, explainAndSeparate, explainAndSeparatePrimitive } = promptConstants;
+
+const UNIT_MS = {
+  ms: 1,
+  millisecond: 1,
+  milliseconds: 1,
+  s: 1000,
+  sec: 1000,
+  secs: 1000,
+  second: 1000,
+  seconds: 1000,
+  m: 60000,
+  min: 60000,
+  mins: 60000,
+  minute: 60000,
+  minutes: 60000,
+  h: 3600000,
+  hr: 3600000,
+  hrs: 3600000,
+  hour: 3600000,
+  hours: 3600000,
+  d: 86400000,
+  day: 86400000,
+  days: 86400000,
+};
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+async function toMs(text) {
+  const clean = String(text).trim();
+  if (ISO_DATE_RE.test(clean)) {
+    const diff = new Date(clean).getTime() - Date.now();
+    if (diff > 0) return diff;
+  }
+  const nu = await numberWithUnits(clean);
+  if (nu && nu.value !== undefined) {
+    const unit = (nu.unit || 'ms').toLowerCase();
+    if (UNIT_MS[unit]) return nu.value * UNIT_MS[unit];
+  }
+  const dt = await date(clean);
+  if (dt instanceof Date) {
+    const diff = dt.getTime() - Date.now();
+    if (diff > 0) return diff;
+  }
+  const n = await number(clean);
+  if (typeof n === 'number') return n;
+  return 0;
+}
+
+export default function setInterval({
+  intervalPrompt,
+  fn,
+  historySize = 5,
+  firstInterval = '0',
+  model,
+} = {}) {
+  let timer;
+  let count = 0;
+  let lastResult;
+  const history = [];
+  let active = true;
+
+  const step = async () => {
+    if (!active) return;
+    const prompt = `${contentIsInstructions} ${intervalPrompt}
+
+${explainAndSeparate} ${explainAndSeparatePrimitive}
+
+Your response should be an ISO date or a short duration like "10 minutes".
+Last result: ${JSON.stringify(lastResult)}
+History: ${history.join(' | ')}
+Next wait:`;
+    const intervalText = await chatGPT(
+      prompt,
+      model ? { modelOptions: { modelName: model } } : undefined
+    );
+    history.push(intervalText);
+    if (history.length > historySize) history.shift();
+    const delay = await toMs(intervalText);
+    lastResult = await fn({
+      count,
+      delay,
+      rawInterval: intervalText,
+      history: [...history],
+      lastInvocationResult: lastResult,
+    });
+    count += 1;
+    timer = setTimeout(step, delay);
+  };
+
+  if (firstInterval === '0' || firstInterval === 0) {
+    timer = setTimeout(step, 0);
+  } else {
+    (async () => {
+      const initialDelay = await toMs(firstInterval);
+      timer = setTimeout(step, initialDelay);
+    })();
+  }
+
+  return () => {
+    active = false;
+    clearTimeout(timer);
+  };
+}

--- a/src/chains/set-interval/index.spec.js
+++ b/src/chains/set-interval/index.spec.js
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import setInterval from './index.js';
+
+vi.useFakeTimers();
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn(),
+}));
+vi.mock('../date/index.js', () => ({
+  default: vi.fn(),
+}));
+vi.mock('../../verblets/number-with-units/index.js', () => ({
+  default: vi.fn(),
+}));
+vi.mock('../../verblets/number/index.js', () => ({
+  default: vi.fn(),
+}));
+
+const chatGPT = (await import('../../lib/chatgpt/index.js')).default;
+const date = (await import('../date/index.js')).default;
+const numberWithUnits = (await import('../../verblets/number-with-units/index.js')).default;
+const number = (await import('../../verblets/number/index.js')).default;
+
+describe('setInterval', () => {
+  it('runs callback with dynamic delays', async () => {
+    chatGPT.mockResolvedValueOnce('1 second').mockResolvedValueOnce('2 seconds');
+    numberWithUnits
+      .mockResolvedValueOnce({ value: 1, unit: 'second' })
+      .mockResolvedValueOnce({ value: 2, unit: 'second' });
+    date.mockResolvedValue(undefined);
+    number.mockResolvedValue(undefined);
+
+    const cb = vi.fn();
+    const stop = setInterval({ intervalPrompt: 'prompt', fn: cb });
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(cb).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(cb).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(cb).toHaveBeenCalledTimes(3);
+    stop();
+    await vi.runOnlyPendingTimersAsync();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import scanJS from './chains/scan-js/index.js';
 
 import sort from './chains/sort/index.js';
 import date from './chains/date/index.js';
+import setInterval from './chains/set-interval/index.js';
 
 import SummaryMap from './chains/summary-map/index.js';
 
@@ -143,6 +144,7 @@ export const verblets = {
   sort,
   date,
   SummaryMap,
+  setInterval,
   test,
   testAdvice,
   bulkGroup,


### PR DESCRIPTION
## Summary
- rename adaptiveInterval to setInterval
- document setInterval in module docs and exports
- clean up README example and update links
- enhance parsing for ISO dates and durations

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_684a54583b0c83328ff1f67dffb84f99