### PR TITLE
Add robust scoring examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,26 +43,26 @@ List operations transform, filter, and organize collections using natural langua
 - [list-expand](./src/verblets/list-expand) - generate additional similar items
 - [intersection](./src/verblets/intersection) - describe common traits between items
 - [sort](./src/chains/sort) - order lists by any describable criteria
+- [bulk-score](./src/chains/bulk-score) - score lists with calibrated examples
 
 ### Content
 
 Content utilities generate, transform, and analyze text while maintaining structure and meaning. They excel at creative tasks, system analysis, and privacy-aware text processing.
 
 - [anonymize](./src/chains/anonymize) - scrub personal details from text
+- [collect-terms](./src/chains/collect-terms) - extract difficult vocabulary
 - [dismantle](./src/chains/dismantle) - break systems into components
 - [disambiguate](./src/chains/disambiguate) - resolve ambiguous word meanings using context
-- [questions](./src/chains/questions) - produce clarifying questions
-- [summary-map](./src/chains/summary-map) - summarize a collection
-- [test](./src/chains/test) - run LLM-driven tests
-- [test-advice](./src/chains/test-advice) - get feedback on test coverage
-- [veiled-variants](./src/chains/veiled-variants) - conceal sensitive queries with safer framing
-- [collect-terms](./src/chains/collect-terms) - extract difficult vocabulary
+- [filter-ambiguous](./src/chains/filter-ambiguous) - find and rank unclear terms for disambiguation
 - [name](./src/verblets/name) - name something from a definition or description
 - [name-similar-to](./src/verblets/name-similar-to) - suggest short names that match a style
+- [questions](./src/chains/questions) - produce clarifying questions
 - [schema-org](./src/verblets/schema-org) - create schema.org objects
 - [socratic](./src/chains/socratic) - explore assumptions using a Socratic dialogue
+- [summary-map](./src/chains/summary-map) - summarize a collection
 - [themes](./src/chains/themes) - identify themes in text
-- [to-object](./src/verblets/to-object) - convert descriptions to objects
+- [to-object](./src/verblets/to-object) - convert descriptions to structured objects
+- [veiled-variants](./src/chains/veiled-variants) - rephrase sensitive queries safely
 
 ### Utility Operations
 

--- a/src/chains/bulk-score/README.md
+++ b/src/chains/bulk-score/README.md
@@ -1,0 +1,16 @@
+# bulk-score
+
+Score lines of text on a 0–10 scale with automatic calibration. Each batch returns a JSON array so parsing stays reliable even with long lists. The chain first scores everything, then rescors a few low, middle, and high examples to calibrate. Those references feed a second scoring pass so every item is ranked consistently using OpenAI's JSON schema enforcement.
+
+```javascript
+import bulkScore from './index.js';
+
+const slogans = [
+  'Amazing deals every day!',
+  'Unlock a world of wonder',
+  'Buy stuff now',
+];
+
+const { scores } = await bulkScore(slogans, 'How catchy is this marketing slogan?');
+// scores like [6, 9, 2]
+```

--- a/src/chains/bulk-score/index.examples.js
+++ b/src/chains/bulk-score/index.examples.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { longTestTimeout } from '../../constants/common.js';
+import bulkScore from './index.js';
+
+describe('bulkScore examples', () => {
+  it(
+    'ranks jokes by humor',
+    async () => {
+      const jokes = [
+        'Why did the chicken cross the road? To get to the other side!',
+        "Parallel lines have so much in common. It's a shame they'll never meet.",
+        "I told my computer I needed a break, and it said 'I'll go to sleep.'",
+      ];
+
+      const { scores } = await bulkScore(jokes, 'How funny is this joke?');
+
+      expect(scores).toHaveLength(jokes.length);
+      scores.forEach((s) => expect(typeof s).toBe('number'));
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/bulk-score/index.js
+++ b/src/chains/bulk-score/index.js
@@ -1,0 +1,83 @@
+import chatGPT from '../../lib/chatgpt/index.js';
+import wrapVariable from '../../prompts/wrap-variable.js';
+import { constants as promptConstants } from '../../prompts/index.js';
+
+const { onlyJSONArray } = promptConstants;
+
+async function scoreBatch(items, instructions, reference = []) {
+  const listBlock = wrapVariable(items.join('\n'), { tag: 'items' });
+  const refBlock = reference.length
+    ? `\nCalibration examples (score - text):\n${wrapVariable(
+        reference.map((r) => `${r.score} - ${r.item}`).join('\n'),
+        { tag: 'reference' }
+      )}`
+    : '';
+
+  const prompt =
+    `Score each line in <items> from 0 (worst) to 10 (best) based on: ${instructions}.` +
+    `\nRespond only with a JSON array of numbers in the same order.` +
+    `${refBlock}\n${onlyJSONArray}\n${listBlock}`;
+
+  const response = await chatGPT(prompt, {
+    modelOptions: {
+      response_format: {
+        type: 'json_object',
+        schema: { type: 'array', items: { type: 'number' } },
+      },
+    },
+  });
+  let arr;
+  try {
+    arr = JSON.parse(response);
+  } catch {
+    throw new Error('Score batch did not return valid JSON');
+  }
+  if (!Array.isArray(arr) || arr.length !== items.length) {
+    throw new Error('Score batch mismatch');
+  }
+  return arr.map((n) => Number(n));
+}
+
+export default async function bulkScore(list, instructions, { chunkSize = 10, examples } = {}) {
+  if (!Array.isArray(list) || list.length === 0) {
+    return { scores: [], reference: [] };
+  }
+
+  const firstScores = [];
+  for (let i = 0; i < list.length; i += chunkSize) {
+    // eslint-disable-next-line no-await-in-loop
+    const scores = await scoreBatch(list.slice(i, i + chunkSize), instructions);
+    firstScores.push(...scores);
+  }
+
+  const scored = list.map((item, idx) => ({ item, score: firstScores[idx] }));
+
+  let reference = examples;
+  if (!reference) {
+    const valid = scored.filter((s) => Number.isFinite(s.score));
+    if (valid.length) {
+      valid.sort((a, b) => a.score - b.score);
+      const lows = valid.slice(0, 3);
+      const highs = valid.slice(-3);
+      const midStart = Math.max(0, Math.floor(valid.length / 2) - 1);
+      const mids = valid.slice(midStart, midStart + 3);
+      reference = [...lows, ...mids, ...highs];
+      const refItems = reference.map((r) => r.item);
+      const rescored = await scoreBatch(refItems, instructions);
+      rescored.forEach((score, idx) => {
+        reference[idx].score = score;
+      });
+    } else {
+      reference = [];
+    }
+  }
+
+  const finalScores = [];
+  for (let i = 0; i < list.length; i += chunkSize) {
+    // eslint-disable-next-line no-await-in-loop
+    const scores = await scoreBatch(list.slice(i, i + chunkSize), instructions, reference);
+    finalScores.push(...scores);
+  }
+
+  return { scores: finalScores, reference };
+}

--- a/src/chains/bulk-score/index.spec.js
+++ b/src/chains/bulk-score/index.spec.js
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import bulkScore from './index.js';
+import chatGPT from '../../lib/chatgpt/index.js';
+
+vi.mock('../../lib/chatgpt/index.js', () => ({
+  default: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('bulkScore chain', () => {
+  it('scores items using two passes', async () => {
+    chatGPT
+      .mockResolvedValueOnce('[1,2,3]')
+      .mockResolvedValueOnce('[1,2,3,4,5,6,7,8,9]')
+      .mockResolvedValueOnce('[1,2,3]');
+    const { scores, reference } = await bulkScore(['a', 'bb', 'ccc'], 'length');
+    expect(scores).toStrictEqual([1, 2, 3]);
+    expect(reference.length).toBeGreaterThan(0);
+    expect(chatGPT).toHaveBeenCalled();
+  });
+
+  it('uses provided examples', async () => {
+    chatGPT.mockResolvedValueOnce('[1]').mockResolvedValueOnce('[1]');
+    const { scores } = await bulkScore(['x'], 'length', { examples: [{ item: 'y', score: 2 }] });
+    expect(scores[0]).toBe(1);
+  });
+});

--- a/src/chains/filter-ambiguous/README.md
+++ b/src/chains/filter-ambiguous/README.md
@@ -1,0 +1,11 @@
+# filter-ambiguous
+
+Identify ambiguous words or phrases in text. Sentences are first scored for overall uncertainty and the highest scoring ones are examined for unclear terms. Each term is scored in context so you can zero in on the most confusing language.
+
+```javascript
+import filterAmbiguous from './index.js';
+
+const text = `I saw her duck\nThe magician made a little girl disappear\nHe fed her dog food`;
+const result = await filterAmbiguous(text, { topN: 3 });
+// => [{ term: 'duck', sentence: 'I saw her duck', score: 9 }, ...]
+```

--- a/src/chains/filter-ambiguous/index.examples.js
+++ b/src/chains/filter-ambiguous/index.examples.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { longTestTimeout } from '../../constants/common.js';
+import filterAmbiguous from './index.js';
+
+describe('filterAmbiguous examples', () => {
+  it(
+    'highlights unclear language',
+    async () => {
+      const text = `I saw her duck\nThe magician made a little girl disappear\nHe fed her dog food`;
+      const result = await filterAmbiguous(text, { topN: 2 });
+      expect(result.length).toBeGreaterThan(0);
+      result.forEach((r) => {
+        expect(r).toHaveProperty('term');
+        expect(r).toHaveProperty('sentence');
+        expect(typeof r.score).toBe('number');
+      });
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/filter-ambiguous/index.js
+++ b/src/chains/filter-ambiguous/index.js
@@ -1,0 +1,46 @@
+import list from '../list/index.js';
+import bulkScore from '../bulk-score/index.js';
+
+export default async function filterAmbiguous(text, { topN = 10, chunkSize = 5 } = {}) {
+  if (!text) return [];
+  const sentences = text
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (sentences.length === 0) return [];
+
+  const { scores: sentenceScores } = await bulkScore(
+    sentences,
+    'How ambiguous or easily misinterpreted is this sentence?',
+    { chunkSize }
+  );
+
+  const rankedSentences = sentences
+    .map((s, i) => ({ sentence: s, score: sentenceScores[i] ?? 0 }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topN);
+
+  const termPairs = [];
+  for (const { sentence } of rankedSentences) {
+    // eslint-disable-next-line no-await-in-loop
+    const terms = await list('Ambiguous words or short phrases', {
+      attachments: { text: sentence },
+      targetNewItemsCount: 5,
+    });
+    terms.forEach((term) => {
+      termPairs.push({ term, sentence });
+    });
+  }
+
+  if (termPairs.length === 0) return [];
+
+  const { scores } = await bulkScore(
+    termPairs.map((p) => `${p.term} | ${p.sentence}`),
+    'Score how ambiguous the term is within the sentence.',
+    { chunkSize }
+  );
+
+  const scored = termPairs.map((p, i) => ({ ...p, score: scores[i] }));
+  scored.sort((a, b) => (b.score || 0) - (a.score || 0));
+  return scored.slice(0, topN);
+}

--- a/src/chains/filter-ambiguous/index.spec.js
+++ b/src/chains/filter-ambiguous/index.spec.js
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import filterAmbiguous from './index.js';
+import bulkScore from '../bulk-score/index.js';
+import list from '../list/index.js';
+
+vi.mock('../bulk-score/index.js', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../list/index.js', () => ({
+  default: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('filterAmbiguous chain', () => {
+  it('returns scored ambiguous terms', async () => {
+    bulkScore
+      .mockResolvedValueOnce({ scores: [1, 9], reference: [] })
+      .mockResolvedValueOnce({ scores: [8, 3], reference: [] });
+    list.mockResolvedValueOnce(['alpha', 'beta']).mockResolvedValueOnce([]);
+
+    const result = await filterAmbiguous('s1\ns2', { topN: 1 });
+
+    expect(result).toStrictEqual([{ term: 'alpha', sentence: 's2', score: 8 }]);
+    expect(bulkScore).toHaveBeenCalled();
+    expect(list).toHaveBeenCalled();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ import scanJS from './chains/scan-js/index.js';
 import sort from './chains/sort/index.js';
 import date from './chains/date/index.js';
 import setInterval from './chains/set-interval/index.js';
+import bulkScore from './chains/bulk-score/index.js';
+import filterAmbiguous from './chains/filter-ambiguous/index.js';
 
 import SummaryMap from './chains/summary-map/index.js';
 import themes from './chains/themes/index.js';
@@ -164,6 +166,8 @@ export const verblets = {
   setInterval,
   test,
   testAdvice,
+  bulkScore,
+  filterAmbiguous,
   bulkGroup,
   bulkFilter,
   listGroup,


### PR DESCRIPTION
## Summary
- refine bullet description for `filter-ambiguous`
- return scores with JSON.parse in `bulk-score`
- add example tests and improved docs for `bulk-score` and `filter-ambiguous`
- improve scoring prompt and enforce JSON schema output

## Testing
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68497d92bdd483329c100e420725e369