### PR TITLE
Add schemas to structured verblets

### DIFF
--- a/src/chains/date/index.js
+++ b/src/chains/date/index.js
@@ -3,6 +3,9 @@ import stripResponse from '../../lib/strip-response/index.js';
 import toDate from '../../lib/to-date/index.js';
 import bool from '../../verblets/bool/index.js';
 import toObject from '../../verblets/to-object/index.js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const schema = require('./schema.json');
 import { constants as promptConstants } from '../../prompts/index.js';
 
 const {
@@ -30,9 +33,11 @@ const buildCheckPrompt = (dateValue, check) => {
 };
 
 export default async function date(text, { maxAttempts = 3 } = {}) {
-  const llmExpectations = (await toObject(await chatGPT(expectationPrompt(text)))) || [
-    'The result is a valid date',
-  ];
+  const llmExpectations = (await toObject(
+    await chatGPT(expectationPrompt(text), {
+      modelOptions: { response_format: { type: 'json_object', schema } },
+    })
+  )) || ['The result is a valid date'];
 
   let attemptText = text;
   let response;

--- a/src/chains/date/schema.json
+++ b/src/chains/date/schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}

--- a/src/chains/disambiguate/index.js
+++ b/src/chains/disambiguate/index.js
@@ -3,6 +3,9 @@ import listFilter from '../../verblets/list-filter/index.js';
 import toObject from '../../verblets/to-object/index.js';
 import { constants as promptConstants } from '../../prompts/index.js';
 import modelService from '../../services/llm-model/index.js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const schema = require('./schema.json');
 
 const { onlyJSONStringArray } = promptConstants;
 
@@ -15,7 +18,10 @@ ${onlyJSONStringArray}`;
 export const getMeanings = async (term, { model = modelService.getBestPublicModel() } = {}) => {
   const prompt = meaningsPrompt(term);
   const budget = model.budgetTokens(prompt);
-  const response = await chatGPT(prompt, { maxTokens: budget.completion });
+  const response = await chatGPT(prompt, {
+    maxTokens: budget.completion,
+    modelOptions: { response_format: { type: 'json_object', schema } },
+  });
   return toObject(response);
 };
 

--- a/src/chains/disambiguate/schema.json
+++ b/src/chains/disambiguate/schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}

--- a/src/chains/dismantle/index.js
+++ b/src/chains/dismantle/index.js
@@ -4,6 +4,9 @@ import chatGPT from '../../lib/chatgpt/index.js';
 import { outputSuccinctNames, constants as promptConstants } from '../../prompts/index.js';
 import modelService from '../../services/llm-model/index.js';
 import toObject from '../../verblets/to-object/index.js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const schema = require('./schema.json');
 
 const { onlyJSONStringArray } = promptConstants;
 
@@ -89,6 +92,7 @@ const defaultDecompose = async ({
         maxTokens: budget.completion,
         frequencyPenalty: 0.7,
         temperature: 0.7,
+        response_format: { type: 'json_object', schema },
       },
     })
   );
@@ -107,6 +111,7 @@ const defaultEnhance = async ({
       maxTokens: budget.completion,
       frequencyPenalty: 0.5,
       temperature: 0.3,
+      modelOptions: { response_format: { type: 'json_object', schema } },
     })
   );
 

--- a/src/chains/dismantle/schema.json
+++ b/src/chains/dismantle/schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": { "type": "string" }
+}

--- a/src/chains/questions/index.js
+++ b/src/chains/questions/index.js
@@ -1,6 +1,9 @@
 import * as R from 'ramda';
 
 import chatGPT from '../../lib/chatgpt/index.js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const schema = require('./schema.json');
 import {
   generateQuestions as generateQuestionsPrompt,
   constants as promptConstants,
@@ -78,7 +81,13 @@ const generateQuestions = async function* generateQuestionsGenerator(text, optio
     };
 
     // eslint-disable-next-line no-await-in-loop
-    const results = await chatGPT(`${promptCreated}`, chatGPTConfig);
+    const results = await chatGPT(`${promptCreated}`, {
+      ...chatGPTConfig,
+      modelOptions: {
+        ...(chatGPTConfig.modelOptions || {}),
+        response_format: { type: 'json_object', schema },
+      },
+    });
     let resultsParsed;
     try {
       // eslint-disable-next-line no-await-in-loop
@@ -88,7 +97,13 @@ const generateQuestions = async function* generateQuestionsGenerator(text, optio
         // eslint-disable-next-line no-await-in-loop
         const resultsUpdated = await chatGPT(
           `${asSplitIntoJSONArray}${onlyJSON} \`\`\`${results}\`\`\``,
-          chatGPTConfig
+          {
+            ...chatGPTConfig,
+            modelOptions: {
+              ...(chatGPTConfig.modelOptions || {}),
+              response_format: { type: 'json_object', schema },
+            },
+          }
         );
         // eslint-disable-next-line no-await-in-loop
         resultsParsed = await toObject(resultsUpdated);

--- a/src/chains/questions/schema.json
+++ b/src/chains/questions/schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": { "type": "string" }
+}

--- a/src/chains/sort/index.js
+++ b/src/chains/sort/index.js
@@ -4,6 +4,9 @@ import chatGPT from '../../lib/chatgpt/index.js';
 import toObject from '../../verblets/to-object/index.js';
 import { sort as sortPromptInitial } from '../../prompts/index.js';
 import modelService from '../../services/llm-model/index.js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const schema = require('./schema.json');
 
 // redeclared so it's clearer how tests can override the sorter
 let sortPrompt = sortPromptInitial;
@@ -65,6 +68,7 @@ const sort = async (options, listInitial, model = modelService.getBestPublicMode
         modelOptions: {
           maxTokens: budget.completion,
           requestTimeout: model.requestTimeout * 1.5,
+          response_format: { type: 'json_object', schema },
         },
       });
 

--- a/src/chains/sort/schema.json
+++ b/src/chains/sort/schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": { "type": "string" }
+}

--- a/src/chains/test/index.js
+++ b/src/chains/test/index.js
@@ -6,6 +6,9 @@ import chatGPT from '../../lib/chatgpt/index.js';
 import { constants as promptConstants, wrapVariable } from '../../prompts/index.js';
 import modelService from '../../services/llm-model/index.js';
 import toObject from '../../verblets/to-object/index.js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const schema = require('./schema.json');
 
 const {
   contentIsExample,
@@ -82,6 +85,7 @@ export default async (
     const checksResult = await chatGPT(checksPromptCreated, {
       modelOptions: {
         maxTokens: checksBudget.completion,
+        response_format: { type: 'json_object', schema },
       },
     });
 
@@ -92,6 +96,7 @@ export default async (
       await chatGPT(testsPromptCreated, {
         modelOptions: {
           maxTokens: testsBudget.completion,
+          response_format: { type: 'json_object', schema },
         },
       })
     );

--- a/src/chains/test/schema.json
+++ b/src/chains/test/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": { "type": "string" },
+      "expected": { "type": "string" },
+      "saw": { "type": "string" },
+      "isSuccess": { "type": "boolean" }
+    },
+    "required": ["name", "expected", "saw"],
+    "additionalProperties": false
+  }
+}

--- a/src/verblets/intent/index.js
+++ b/src/verblets/intent/index.js
@@ -2,6 +2,9 @@ import enums from '../enum/index.js';
 import toObject from '../to-object/index.js';
 import chatGPT from '../../lib/chatgpt/index.js';
 import stripResponse from '../../lib/strip-response/index.js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const schema = require('./schema.json');
 
 import { constants, intent, wrapVariable } from '../../prompts/index.js';
 
@@ -56,7 +59,10 @@ export default async ({ text, operations, defaultIntent = completionIntent, opti
       operations: operationsFound,
       parameters: parametersFound,
     }),
-    options
+    {
+      modelOptions: { response_format: { type: 'json_object', schema } },
+      ...options,
+    }
   );
 
   return toObject(stripResponse(result));

--- a/src/verblets/intent/schema.json
+++ b/src/verblets/intent/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/schemas/intent-schema.json",
+  "type": "object",
+  "properties": {
+    "queryText": {
+      "type": "string",
+      "description": "The user's query text."
+    },
+    "intent": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string",
+          "description": "The operation associated with the intent."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the intent."
+        }
+      },
+      "required": ["operation", "displayName"],
+      "description": "Information about the intent."
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Parameters associated with the intent."
+    },
+    "optionalParameters": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional parameters associated with the intent."
+    }
+  },
+  "required": ["queryText", "intent"],
+  "description": "Schema for an intent response."
+}

--- a/src/verblets/intersection/index.js
+++ b/src/verblets/intersection/index.js
@@ -1,6 +1,9 @@
 import chatGPT from '../../lib/chatgpt/index.js';
 import wrapVariable from '../../prompts/wrap-variable.js';
 import { constants as promptConstants } from '../../prompts/index.js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const schema = require('./schema.json');
 
 const { contentIsQuestion, tryCompleteData, onlyJSONStringArray } = promptConstants;
 
@@ -22,7 +25,9 @@ ${tryCompleteData} ${onlyJSONStringArray}`;
 
 export default async function intersection(items, options = {}) {
   if (!Array.isArray(items) || items.length < 2) return [];
-  const output = await chatGPT(buildPrompt(items, options));
+  const output = await chatGPT(buildPrompt(items, options), {
+    modelOptions: { response_format: { type: 'json_object', schema } },
+  });
 
   try {
     const parsed = JSON.parse(output.trim());

--- a/src/verblets/intersection/index.spec.js
+++ b/src/verblets/intersection/index.spec.js
@@ -45,7 +45,10 @@ describe('intersection verblet', () => {
   it('includes custom instructions in the prompt', async () => {
     const chatGPT = (await import('../../lib/chatgpt/index.js')).default;
     await intersection(['x', 'y', 'z'], { instructions: 'focus on features' });
-    expect(chatGPT).toHaveBeenCalledWith(expect.stringContaining('focus on features'));
+    expect(chatGPT).toHaveBeenCalledWith(
+      expect.stringContaining('focus on features'),
+      expect.anything()
+    );
   });
 
   it('returns empty array when model returns empty response', async () => {

--- a/src/verblets/intersection/schema.json
+++ b/src/verblets/intersection/schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}


### PR DESCRIPTION
## Summary
- use `response_format` schemas for several chains and verblets
- load schemas via `createRequire` to avoid JSON import issues
- fix intersection spec for new chatGPT call

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_684e4166af448332aaded79d57583149