### PR TITLE
Clarify instructions usage in intersections

### DIFF
--- a/src/chains/intersections/README.md
+++ b/src/chains/intersections/README.md
@@ -9,11 +9,14 @@ Imagine you're planning activities that work for different groups of people. Let
 ```javascript
 import intersections from './index.js';
 
-const result = await intersections([
-  'outdoor enthusiasts', 
-  'food lovers', 
-  'budget-conscious friends'
-]);
+
+const result = await intersections(
+  ['outdoor enthusiasts', 'food lovers', 'budget-conscious friends'],
+  {
+    instructions:
+      'Only return real weekend activities and skip abstract themes.',
+  }
+);
 
 console.log(result);
 ```
@@ -118,6 +121,15 @@ const results = await intersections(['hiking', 'photography', 'meditation'], {
   maxSize: 3            // Maximum 3 items per combination
 });
 
+// Restrict the type of elements returned
+const workshopsOnly = await intersections(
+  ['painting', 'sculpture', 'digital art'],
+  {
+    instructions:
+      'List concrete workshop ideas that combine these arts. Avoid themes or vague descriptions.',
+  }
+);
+
 // Error handling
 try {
   const results = await intersections(['incompatible', 'categories'], {
@@ -135,7 +147,9 @@ try {
 - **Higher `goodnessScore`** (8-9) for stricter quality requirements  
 - **Increase `batchSize`** (10-15) for faster processing with good API limits
 - **Decrease `batchSize`** (2-3) to be gentler on API rate limits
-- **Use `instructions`** to guide the AI toward specific types of intersections
+- **Use `instructions`** to tell the AI exactly what kind of elements to return.
+  For example, you can request only hands-on workshop ideas and exclude vague
+  themes or abstract categories.
 
 ## Quality Assurance
 

--- a/src/chains/intersections/index.examples.js
+++ b/src/chains/intersections/index.examples.js
@@ -246,7 +246,8 @@ describe('intersections chain examples', () => {
   it(
     'validates custom instructions and configuration',
     async () => {
-      const customInstructions = 'Focus on practical applications and real-world examples';
+      const customInstructions =
+        'List concrete project ideas that combine these fields. Avoid abstract themes.';
       const result = await intersections(['engineering', 'design'], {
         instructions: customInstructions,
         batchSize: 2,
@@ -269,7 +270,7 @@ describe('intersections chain examples', () => {
         const [followsInstructions] = await aiExpect(
           firstIntersection,
           undefined,
-          'Should contain practical applications and real-world examples as requested in custom instructions'
+          'Should list specific project ideas and avoid abstract themes as requested in custom instructions'
         );
         expect(followsInstructions).toBe(true);
       }


### PR DESCRIPTION
## Summary
- document how to restrict intersection results to concrete items
- show a new workshops example in README
- update example test to avoid abstract themes

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_684f7c50d2a88332b7b544c0eef2890e