### PR TITLE
Add detect-patterns chain and fix truncate tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ List operations transform, filter, and organize collections using natural langua
 - [list](./src/chains/list) - generate contextual lists from prompts
 - [list-expand](./src/verblets/list-expand) - generate additional similar items
 - [sort](./src/chains/sort) - order lists by any describable criteria
+- [detect-patterns](./src/chains/detect-patterns) - find recurring patterns in object collections
 
 ### Content
 

--- a/src/chains/detect-patterns/index.examples.js
+++ b/src/chains/detect-patterns/index.examples.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import detectPatterns from './index.js';
+import { longTestTimeout } from '../../constants/common.js';
+
+describe('detect-patterns examples', () => {
+  it(
+    'should detect patterns in user settings objects',
+    async () => {
+      const userSettings = [
+        { theme: 'dark', fontSize: 14, autoSave: true, language: 'en' },
+        { theme: 'light', fontSize: 12, autoSave: false, language: 'en' },
+        { theme: 'dark', fontSize: 16, autoSave: true, language: 'es' },
+        { theme: 'dark', fontSize: 14, autoSave: true, language: 'fr' },
+        { theme: 'light', fontSize: 12, autoSave: false, language: 'en' },
+        { theme: 'system', fontSize: 14, autoSave: true, language: 'en' },
+        { theme: 'dark', fontSize: 18, autoSave: true, language: 'en' },
+        { theme: 'light', fontSize: 10, autoSave: false, language: 'de' },
+      ];
+
+      const patterns = await detectPatterns(userSettings, {
+        topN: 3,
+        candidateWindow: 15,
+      });
+
+      expect(patterns).to.be.an('array');
+      expect(patterns.length).to.be.at.most(3);
+
+      // Should find patterns like dark theme with auto-save, light theme without auto-save
+    },
+    longTestTimeout
+  );
+
+  it(
+    'should detect patterns in e-commerce product configurations',
+    async () => {
+      const products = [
+        { category: 'electronics', price: 299, inStock: true, shipping: 'free', rating: 4.5 },
+        { category: 'electronics', price: 199, inStock: false, shipping: 'paid', rating: 4.2 },
+        { category: 'books', price: 15, inStock: true, shipping: 'free', rating: 4.8 },
+        { category: 'books', price: 12, inStock: true, shipping: 'free', rating: 4.6 },
+        { category: 'electronics', price: 599, inStock: true, shipping: 'free', rating: 4.7 },
+        { category: 'clothing', price: 45, inStock: true, shipping: 'paid', rating: 4.1 },
+        { category: 'clothing', price: 35, inStock: false, shipping: 'paid', rating: 3.9 },
+        { category: 'books', price: 18, inStock: true, shipping: 'free', rating: 4.9 },
+      ];
+
+      const patterns = await detectPatterns(products, {
+        topN: 2,
+        candidateWindow: 10,
+      });
+
+      expect(patterns).to.be.an('array');
+      expect(patterns.length).to.be.equal(2);
+    },
+    longTestTimeout
+  );
+});

--- a/src/chains/detect-patterns/index.js
+++ b/src/chains/detect-patterns/index.js
@@ -1,0 +1,100 @@
+import reduce from '../reduce/index.js';
+
+function filterObject(obj, maxStringLength = 50, maxArrayLength = 10) {
+  if (typeof obj !== 'object' || obj === null) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    if (obj.length > maxArrayLength) {
+      return `Array(${obj.length})`;
+    }
+    return obj.map((item) => filterObject(item, maxStringLength, maxArrayLength));
+  }
+
+  const filtered = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'string' && value.length > maxStringLength) {
+      filtered[key] = `String(${value.length})`;
+    } else if (typeof value === 'object') {
+      filtered[key] = filterObject(value, maxStringLength, maxArrayLength);
+    } else {
+      filtered[key] = value;
+    }
+  }
+
+  return filtered;
+}
+
+export default async function detectPatterns(objects, config = {}) {
+  const { topN = 5, maxStringLength = 50, maxArrayLength = 10, llm, ...options } = config;
+
+  const filteredObjects = objects.map((obj) => filterObject(obj, maxStringLength, maxArrayLength));
+  const stringifiedObjects = filteredObjects.map((obj) => JSON.stringify(obj, null, 0));
+
+  const patternInstructions = `
+    Maintain an array of pattern candidates and individual instances. Maximum 50 total items.
+    
+    Each item format: {"type": "pattern"|"instance", "template": {...}, "count": N}
+    - "pattern": merged from 2+ objects, count >= 2
+    - "instance": single object not yet merged, count = 1
+    
+    GREEDY ACCUMULATION STRATEGY:
+    - For each new object, try to merge with most similar existing item
+    - If merge possible: update template constraints, increment count, change type to "pattern" if count >= 2
+    - If no merge: add as new "instance" if space allows
+    
+    VALUE CONSTRAINT EVOLUTION:
+    - Instances: use literal values from the single object
+    - Patterns: promote to constraints when merging objects with different values:
+      * { range: [min, max] } for varying numbers
+      * { values: [val1, val2, ...] } for varying discrete values
+    - Keep literal values when all merged objects have identical value
+    
+    CAPACITY MANAGEMENT (when at 50 items):
+    - Try merging new object with best match first
+    - If no merge possible, evict lowest count instance
+    - Prioritize keeping patterns over instances
+    
+    Sort array by count descending (patterns first, then instances).
+    
+    Return the JSON array of all candidates. If the input list is empty, return an empty array [].
+  `;
+
+  const ndjsonResult = await reduce(stringifiedObjects, patternInstructions, {
+    initial: '[]',
+    llm,
+    ...options,
+  });
+
+  // Parse result array and extract only patterns (not instances)
+  let candidateArray;
+  try {
+    let jsonString = ndjsonResult;
+    if (typeof jsonString === 'string') {
+      // Extract JSON from code blocks if present
+      const codeBlockMatch = jsonString.match(/```json\s*([\s\S]*?)\s*```/);
+      if (codeBlockMatch) {
+        jsonString = codeBlockMatch[1];
+      }
+      candidateArray = JSON.parse(jsonString);
+    } else {
+      candidateArray = ndjsonResult;
+    }
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(candidateArray)) {
+    return [];
+  }
+
+  // Filter to only patterns (count >= 2) and extract templates
+  const patterns = candidateArray
+    .filter((item) => item.type === 'pattern' && item.count >= 2)
+    .sort((a, b) => b.count - a.count)
+    .map((item) => item.template)
+    .slice(0, topN);
+
+  return patterns;
+}

--- a/src/chains/detect-patterns/index.spec.js
+++ b/src/chains/detect-patterns/index.spec.js
@@ -1,0 +1,118 @@
+import { expect } from 'chai';
+import { vi, describe, beforeEach, it } from 'vitest';
+import detectPatterns from './index.js';
+
+vi.mock('../reduce/index.js', () => ({
+  default: vi.fn(),
+}));
+
+import reduce from '../reduce/index.js';
+
+describe('detect-patterns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return empty array for empty input', async () => {
+    reduce.mockResolvedValueOnce('[]');
+    const result = await detectPatterns([]);
+    expect(result).to.deep.equal([]);
+  });
+
+  it('should process objects and return pattern templates', async () => {
+    const mockResult = [
+      {
+        type: 'pattern',
+        template: { theme: { values: ['dark', 'light'] }, fontSize: { range: [12, 16] } },
+        count: 5,
+      },
+      {
+        type: 'pattern',
+        template: { category: { values: ['books'] }, price: { range: [10, 20] } },
+        count: 3,
+      },
+    ];
+
+    reduce.mockResolvedValueOnce(JSON.stringify(mockResult));
+
+    const objects = [
+      { theme: 'dark', fontSize: 14 },
+      { theme: 'light', fontSize: 12 },
+    ];
+
+    const result = await detectPatterns(objects, { topN: 2 });
+
+    expect(result).to.be.an('array');
+    expect(result).to.have.length(2);
+    expect(result[0]).to.deep.equal({
+      theme: { values: ['dark', 'light'] },
+      fontSize: { range: [12, 16] },
+    });
+    expect(result[1]).to.deep.equal({
+      category: { values: ['books'] },
+      price: { range: [10, 20] },
+    });
+  });
+
+  it('should handle JSON with code blocks', async () => {
+    const mockResult = [
+      {
+        type: 'pattern',
+        template: { theme: { values: ['dark'] } },
+        count: 3,
+      },
+      {
+        type: 'pattern',
+        template: { size: { range: [10, 20] } },
+        count: 2,
+      },
+    ];
+
+    const mockResponse = `\`\`\`json\n${JSON.stringify(mockResult, null, 2)}\n\`\`\``;
+    reduce.mockResolvedValueOnce(mockResponse);
+
+    const objects = [{ theme: 'dark' }];
+    const result = await detectPatterns(objects, { topN: 2 });
+
+    expect(result).to.have.length(2);
+    expect(result[0]).to.deep.equal({ theme: { values: ['dark'] } });
+  });
+
+  it('should handle malformed JSON gracefully', async () => {
+    const mockResponse = 'malformed json response';
+
+    reduce.mockResolvedValueOnce(mockResponse);
+
+    const objects = [{ theme: 'dark' }];
+    const result = await detectPatterns(objects, { topN: 2 });
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it('should respect topN limit', async () => {
+    const mockResult = [
+      {
+        type: 'pattern',
+        template: { a: 1 },
+        count: 5,
+      },
+      {
+        type: 'pattern',
+        template: { b: 2 },
+        count: 4,
+      },
+      {
+        type: 'pattern',
+        template: { c: 3 },
+        count: 3,
+      },
+    ];
+
+    reduce.mockResolvedValueOnce(JSON.stringify(mockResult));
+
+    const objects = [{ a: 1 }];
+    const result = await detectPatterns(objects, { topN: 2 });
+
+    expect(result).to.have.length(2);
+  });
+});

--- a/src/chains/truncate/index.js
+++ b/src/chains/truncate/index.js
@@ -96,13 +96,6 @@ Consider the removal criteria above when scoring.`;
     // Don't use stopOnThreshold - we need all scores to find high ones
   });
 
-  // Debug: log the scores to understand what's happening
-  console.log('Truncate debug:', {
-    threshold,
-    scores: result.scores,
-    chunks: textsToScore.map((t, i) => ({ index: i, text: `${t.substring(0, 50)}...` })),
-  });
-
   // Find the first chunk (from the end) that should be removed (score < threshold)
   const removeChunkIndex = result.scores.findIndex((score) => score < threshold);
 

--- a/src/chains/truncate/index.spec.js
+++ b/src/chains/truncate/index.spec.js
@@ -56,7 +56,7 @@ describe('truncate', () => {
     });
 
     it('returns full length when all content meets criteria', async () => {
-      score.mockResolvedValueOnce({ scores: [8, 7, 6, 5, 4], reference: [] });
+      score.mockResolvedValueOnce({ scores: [8, 7, 6], reference: [] });
       const text = 'All content is important';
       const result = await truncate(text, 'Remove boring content');
       expect(result).toBe(text.length);
@@ -97,7 +97,6 @@ describe('truncate', () => {
           chunkSize: 5,
           llm: { modelName: 'custom' },
           customOption: 'value',
-          stopOnThreshold: 6,
         })
       );
     });

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ import categorySamples from './chains/category-samples/index.js';
 import veiledVariants from './chains/veiled-variants/index.js';
 import expectChain from './chains/expect/index.js';
 import * as llmLogger from './chains/llm-logger/index.js';
+import detectPatterns from './chains/detect-patterns/index.js';
 
 import schemas from './json-schemas/index.js';
 import * as common from './constants/common.js';
@@ -148,6 +149,7 @@ export {
   veiledVariants,
   expectChain,
   truncate,
+  detectPatterns,
 };
 export { llmLogger };
 export { rangeCombinations } from './lib/combinations/index.js';
@@ -232,6 +234,7 @@ export const verblets = {
   veiledVariants,
   expectChain,
   truncate,
+  detectPatterns,
 };
 
 export const services = {


### PR DESCRIPTION
- Add detect-patterns chain for finding recurring patterns in object collections
- Uses LLM-powered reduce to identify common patterns across datasets
- Supports value constraints (ranges, discrete values) and pattern merging
- Handles JSON parsing from LLM responses including code blocks

🤖 Generated with [Claude Code](https://claude.ai/code)