### PR TITLE
Fix README titles and streamline docs

### DIFF
--- a/src/chains/expect/README.md
+++ b/src/chains/expect/README.md
@@ -1,4 +1,4 @@
-# LLM Expect Chain
+# expect
 
 Advanced intelligent assertions with debugging features, environment variable modes, and structured results. This chain provides enhanced functionality beyond the basic [expect verblet](../../verblets/expect/).
 

--- a/src/chains/list/README.md
+++ b/src/chains/list/README.md
@@ -1,4 +1,4 @@
-# List Generation Chain
+# list
 
 Generate contextual lists from natural language prompts using AI-powered content creation. This chain produces relevant, diverse items based on your specifications, with support for streaming generation and custom filtering.
 

--- a/src/chains/questions/README.md
+++ b/src/chains/questions/README.md
@@ -1,4 +1,4 @@
-# Questions Chain
+# questions
 
 AI-powered question generator that creates relevant, thought-provoking questions from any input text. Uses an iterative approach to explore different angles and drill down into interesting areas.
 

--- a/src/chains/summary-map/README.md
+++ b/src/chains/summary-map/README.md
@@ -1,4 +1,4 @@
-# Summary Map Chain
+# summary-map
 
 SummaryMap is a hash table with auto-resizing values that resize upon serialization. It can be used to keep the overall size of a hash of items within a fixed budget. A primary use case for this is keeping prompts full of various pieces of context fixed to a desired size. The chain manages collections of data elements by compressing them based on weights and token budgets, enabling efficient context management for language model interactions.
 

--- a/src/verblets/list-expand/README.md
+++ b/src/verblets/list-expand/README.md
@@ -27,11 +27,8 @@ Returns an array containing the original items plus additional items that fit th
 
 ## Use Cases
 
-- Brainstorming and idea generation
-- Creating comprehensive lists from partial examples
-- Expanding seed data for testing or prototyping
-- Generating variations on a theme
-- Building complete datasets from sample items
+Common scenarios include brainstorming new ideas, expanding small seed lists for testing,
+and building complete datasets from a handful of samples.
 
 ## Advanced Usage
 


### PR DESCRIPTION
## Summary
- remove `Chain` from chain README titles
- clarify use cases in list-expand README

## Testing
- `npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.` (from commit)

------
https://chatgpt.com/codex/tasks/task_b_6875c7282e8483328c9635234bbfa499