### PR TITLE
Add cli-config chain

### DIFF
--- a/src/chains/README.md
+++ b/src/chains/README.md
@@ -18,6 +18,7 @@ Available chains:
 - [glossary](./glossary)
 - [scan-js](./scan-js)
 - [sort](./sort)
+- [cli-config](./cli-config)
 - [summary-map](./summary-map)
 - [themes](./themes)
 - [set-interval](./set-interval)

--- a/src/chains/cli-config/README.md
+++ b/src/chains/cli-config/README.md
@@ -1,0 +1,15 @@
+# cli-config
+
+Translate a natural language CLI request into a structured configuration object. Large configuration specs are processed in chunks using `bulkReduce` so you always end up with valid values.
+
+```javascript
+import cliConfig from './index.js';
+
+const spec = {
+  port: { default: 8080 },
+  env: { default: 'development', enum: ['development', 'production'] },
+};
+
+const cfg = await cliConfig('run in production on port 3000', spec);
+// => { port: 3000, env: 'production' }
+```

--- a/src/chains/cli-config/index.js
+++ b/src/chains/cli-config/index.js
@@ -1,0 +1,38 @@
+import bulkReduce from '../bulk-reduce/index.js';
+import { constants as promptConstants } from '../../prompts/index.js';
+import stripResponse from '../../lib/strip-response/index.js';
+
+const { onlyJSON } = promptConstants;
+
+function buildDefaults(spec) {
+  const defaults = {};
+  Object.entries(spec).forEach(([key, def]) => {
+    if (Object.hasOwn(def, 'default')) {
+      defaults[key] = def.default;
+    }
+  });
+  return defaults;
+}
+
+export default async function cliConfig(text, spec = {}, config = {}) {
+  const { chunkSize = 5, llm, ...options } = config;
+  const fields = Object.keys(spec);
+  const defaults = buildDefaults(spec);
+
+  const instructions =
+    `${onlyJSON}\nCLI argument: "${text}"\n` +
+    'Each item in <list> is a property name from the specification. ' +
+    'Update the <accumulator> JSON object for each property using information from the CLI argument. ' +
+    "Use the property's default value if no value is specified. " +
+    'If the spec lists enum options, the value must be one of them.\n\n' +
+    `Specification: ${JSON.stringify(spec)}`;
+
+  const resultString = await bulkReduce(fields, instructions, {
+    chunkSize,
+    initial: JSON.stringify(defaults),
+    llm,
+    ...options,
+  });
+
+  return JSON.parse(stripResponse(resultString));
+}

--- a/src/chains/cli-config/index.spec.js
+++ b/src/chains/cli-config/index.spec.js
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import cliConfig from './index.js';
+import bulkReduce from '../bulk-reduce/index.js';
+
+vi.mock('../bulk-reduce/index.js', () => ({
+  default: vi.fn(async (_fields, _instructions, config) => config.initial),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('cli-config chain', () => {
+  it('returns defaults when bulk reduce makes no changes', async () => {
+    const spec = { port: { default: 8080 }, env: { default: 'dev' } };
+    const result = await cliConfig('no overrides', spec);
+    expect(result).toStrictEqual({ port: 8080, env: 'dev' });
+    expect(bulkReduce).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import date from './chains/date/index.js';
 import setInterval from './chains/set-interval/index.js';
 import bulkScore from './chains/bulk-score/index.js';
 import filterAmbiguous from './chains/filter-ambiguous/index.js';
+import cliConfig from './chains/cli-config/index.js';
 
 import SummaryMap from './chains/summary-map/index.js';
 import themes from './chains/themes/index.js';
@@ -178,6 +179,7 @@ export const verblets = {
   conversationTurnMulti,
   bulkScore,
   filterAmbiguous,
+  cliConfig,
   bulkGroup,
   bulkFilter,
   listGroup,


### PR DESCRIPTION
## Summary
- add `cli-config` chain for transforming plain English CLI text into configuration
- export new chain from library and document it in Chains README
- test cli-config

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_6858bfb993748332b6f533f8df06c10b