### PR TITLE
Collection reshape

### DIFF
--- a/src/chains/anonymize/index.examples.js
+++ b/src/chains/anonymize/index.examples.js
@@ -98,9 +98,12 @@ describe('anonymize collection operations', () => {
     'maps anonymization across items',
     { timeout: 60_000 },
     async () => {
-      const instructions = await mapInstructions(
-        'Remove personal and company names from technical insights'
-      );
+      // First generate the anonymization spec
+      const spec = await anonymizeSpec('Remove personal and company names from technical insights');
+
+      const instructions = mapInstructions({
+        specification: spec,
+      });
 
       const results = await map(techTexts, instructions);
 
@@ -134,9 +137,12 @@ describe('anonymize collection operations', () => {
     'reduces with final anonymization',
     { timeout: 60_000 },
     async () => {
-      const instructions = await reduceInstructions({
+      // First generate the anonymization spec
+      const spec = await anonymizeSpec('Remove all identifiers from the final summary');
+
+      const instructions = reduceInstructions({
+        specification: spec,
         processing: 'Combine insights into a unified technical summary',
-        anonymization: 'Remove all identifiers from the final summary',
       });
 
       const summary = await reduce(techTexts, instructions);
@@ -176,21 +182,19 @@ describe('anonymize collection operations', () => {
       expect(spec.length).to.be.greaterThan(50);
 
       // Use the spec in map instructions
-      const instructions1 = await mapInstructions(
-        { anonymization: spec, processing: 'Process reviews batch 1' },
-        {},
-        () => spec
-      );
+      const instructions1 = mapInstructions({
+        specification: spec,
+        processing: 'Process reviews batch 1',
+      });
 
-      const instructions2 = await mapInstructions(
-        { anonymization: spec, processing: 'Process reviews batch 2' },
-        {},
-        () => spec
-      );
+      const instructions2 = mapInstructions({
+        specification: spec,
+        processing: 'Process reviews batch 2',
+      });
 
-      // Both should have the same specification
-      expect(instructions1.specification).toBe(spec);
-      expect(instructions2.specification).toBe(spec);
+      // Both instructions should contain the specification
+      expect(instructions1).to.include(spec);
+      expect(instructions2).to.include(spec);
 
       // Test with sample data
       const batch1 = ['Alice from TechCorp loves the new features'];

--- a/src/chains/anonymize/index.spec.js
+++ b/src/chains/anonymize/index.spec.js
@@ -64,9 +64,8 @@ describe('core functions', () => {
 
 describe('collection instruction builders', () => {
   // Shared test helper for instruction builders
-  const testInstructionBuilder = async (builderFn, config, expectedContent) => {
-    const instructions = await builderFn(config);
-    expect(instructions.specification).toBe(mockSpec);
+  const testInstructionBuilder = (builderFn, params, expectedContent) => {
+    const instructions = builderFn(params);
 
     const text = toText(instructions);
     expectedContent.forEach((content) => {
@@ -76,65 +75,65 @@ describe('collection instruction builders', () => {
     return instructions;
   };
 
-  it('mapInstructions creates proper instructions', async () => {
-    await testInstructionBuilder(
+  it('mapInstructions creates proper instructions', () => {
+    testInstructionBuilder(
       mapInstructions,
       {
-        anonymization: 'Remove personal data',
+        specification: mockSpec,
         processing: 'Process each review independently',
       },
       ['processing-instructions', 'anonymization-specification']
     );
 
-    // Test backward compatibility
-    const stringInput = await mapInstructions('Simple anonymization');
-    expect(stringInput.specification).toBe(mockSpec);
+    // Test without processing
+    const simpleInstructions = mapInstructions({ specification: mockSpec });
+    expect(simpleInstructions).toContain('anonymization-specification');
   });
 
-  it('filterInstructions handles criteria and defaults', async () => {
-    await testInstructionBuilder(
+  it('filterInstructions handles criteria and defaults', () => {
+    testInstructionBuilder(
       filterInstructions,
       {
-        anonymization: 'Remove sensitive data',
+        specification: mockSpec,
         processing: 'Keep financial information',
       },
       ['filter-criteria', 'anonymization-specification']
     );
 
     // Test default behavior
-    await testInstructionBuilder(filterInstructions, { anonymization: 'Standard anonymization' }, [
+    testInstructionBuilder(filterInstructions, { specification: mockSpec }, [
       'moderate threshold',
       'anonymization-specification',
     ]);
   });
 
-  it('reduceInstructions combines properly', async () => {
-    await testInstructionBuilder(
+  it('reduceInstructions combines properly', () => {
+    testInstructionBuilder(
       reduceInstructions,
       {
-        anonymization: 'Anonymize final summary',
+        specification: mockSpec,
         processing: 'Combine customer feedback',
       },
       ['reduce-operation', 'final accumulated result']
     );
   });
 
-  it('findInstructions selects correctly', async () => {
-    await testInstructionBuilder(
+  it('findInstructions selects correctly', () => {
+    testInstructionBuilder(
       findInstructions,
       {
-        anonymization: 'Anonymize selected',
+        specification: mockSpec,
         processing: 'Find most sensitive',
       },
       ['selection-criteria', 'selected item']
     );
   });
 
-  it('groupInstructions organizes properly', async () => {
-    await testInstructionBuilder(
+  it('groupInstructions organizes properly', () => {
+    testInstructionBuilder(
       groupInstructions,
       {
-        anonymization: 'Anonymize grouped data',
+        specification: mockSpec,
         processing: 'Group by type and sensitivity',
       },
       ['grouping-strategy', 'within each group']

--- a/src/chains/entities/index.js
+++ b/src/chains/entities/index.js
@@ -115,171 +115,105 @@ export async function extractEntities(text, instructions, config = {}) {
 // ===== Instruction Builders =====
 
 /**
- * Helper to create instruction with attached specification
- * @param {string} instructions - The instruction string
- * @param {string} specification - The specification text
- * @param {boolean} returnTuple - Whether to return as tuple
- * @returns {string|Object} Instructions with specification attached or tuple
- */
-function createInstructionResult(instructions, specification, returnTuple) {
-  if (returnTuple) {
-    return { value: instructions, specification };
-  }
-  // Attach specification as a property to the string
-  return Object.assign(instructions, { specification });
-}
-
-/**
  * Create map instructions for entity extraction
- * @param {string|Object} instructions - Entity extraction string or instructions object
- * @param {string} instructions.entities - What entities to extract
- * @param {string} instructions.processing - Additional processing instructions (optional)
- * @param {Object} config - Configuration options
- * @param {boolean} config.returnTuple - Return {value, specification} instead of string with property
- * @param {Function} createSpec - Spec generation function (defaults to entitySpec)
- * @returns {Promise<string|Object>} Instructions string with specification property, or tuple if configured
+ * @param {Object} params - Parameters object
+ * @param {string} params.specification - Pre-generated entity specification
+ * @param {string} params.processing - Additional processing instructions (optional)
+ * @returns {string} Instructions string
  */
-export async function mapInstructions(instructions, config = {}, createSpec = entitySpec) {
-  // Handle backward compatibility - if instructions is a string, use it as entities
-  const entities = typeof instructions === 'string' ? instructions : instructions.entities;
-  const processing = typeof instructions === 'object' ? instructions.processing : null;
-  const { returnTuple, ...specConfig } = config;
-  const specification = await createSpec(entities, specConfig);
-
-  let combinedInstructions;
+export function mapInstructions({ specification, processing }) {
   if (processing) {
-    combinedInstructions = `${asXML(processing, { tag: 'processing-instructions' })}
+    return `${asXML(processing, { tag: 'processing-instructions' })}
 
 Apply this entity specification:
 ${asXML(specification, { tag: 'entity-specification' })}`;
   } else {
-    combinedInstructions = `${DEFAULT_MAP_INSTRUCTIONS}
+    return `${DEFAULT_MAP_INSTRUCTIONS}
 
 ${asXML(specification, { tag: 'entity-specification' })}`;
   }
-
-  return createInstructionResult(combinedInstructions, specification, returnTuple);
 }
 
 /**
  * Create filter instructions for entity extraction
- * @param {Object} instructions - Instructions object
- * @param {string} instructions.entities - What entities to extract
- * @param {string} instructions.processing - Filter criteria (optional)
- * @param {Object} config - Configuration options
- * @param {boolean} config.returnTuple - Return {value, specification} instead of string with property
- * @param {Function} createSpec - Spec generation function (defaults to entitySpec)
- * @returns {Promise<string|Object>} Instructions string with specification property, or tuple if configured
+ * @param {Object} params - Parameters object
+ * @param {string} params.specification - Pre-generated entity specification
+ * @param {string} params.processing - Filter criteria (optional)
+ * @returns {string} Instructions string
  */
-export async function filterInstructions(instructions, config = {}, createSpec = entitySpec) {
-  const { entities, processing } = instructions;
-  const { returnTuple, ...specConfig } = config;
-  const specification = await createSpec(entities, specConfig);
-
-  let combinedInstructions;
+export function filterInstructions({ specification, processing }) {
   if (processing) {
-    combinedInstructions = `${asXML(processing, { tag: 'filter-criteria' })}
+    return `${asXML(processing, { tag: 'filter-criteria' })}
 
 ${FILTER_PROCESS_STEPS}
 
 ${asXML(specification, { tag: 'entity-specification' })}`;
   } else {
-    combinedInstructions = `${DEFAULT_FILTER_INSTRUCTIONS}
+    return `${DEFAULT_FILTER_INSTRUCTIONS}
 
 ${asXML(specification, { tag: 'entity-specification' })}`;
   }
-
-  return createInstructionResult(combinedInstructions, specification, returnTuple);
 }
 
 /**
  * Create reduce instructions for entity extraction
- * @param {Object} instructions - Instructions object
- * @param {string} instructions.entities - What entities to extract
- * @param {string} instructions.processing - How to consolidate entities (optional)
- * @param {Object} config - Configuration options
- * @param {boolean} config.returnTuple - Return {value, specification} instead of string with property
- * @param {Function} createSpec - Spec generation function (defaults to entitySpec)
- * @returns {Promise<string|Object>} Instructions string with specification property, or tuple if configured
+ * @param {Object} params - Parameters object
+ * @param {string} params.specification - Pre-generated entity specification
+ * @param {string} params.processing - How to consolidate entities (optional)
+ * @returns {string} Instructions string
  */
-export async function reduceInstructions(instructions, config = {}, createSpec = entitySpec) {
-  const { entities, processing } = instructions;
-  const { returnTuple, ...specConfig } = config;
-  const specification = await createSpec(entities, specConfig);
-
+export function reduceInstructions({ specification, processing }) {
   const defaultProcessing = `Build comprehensive entity list from all chunks`;
 
-  const combinedInstructions = `${asXML(processing || defaultProcessing, {
+  return `${asXML(processing || defaultProcessing, {
     tag: 'reduce-operation',
   })}
 
 ${REDUCE_PROCESS_STEPS}
 
 ${asXML(specification, { tag: 'entity-specification' })}`;
-
-  return createInstructionResult(combinedInstructions, specification, returnTuple);
 }
 
 /**
  * Create find instructions for entity extraction
- * @param {Object} instructions - Instructions object
- * @param {string} instructions.entities - What entities to extract
- * @param {string} instructions.processing - Selection criteria (optional)
- * @param {Object} config - Configuration options
- * @param {boolean} config.returnTuple - Return {value, specification} instead of string with property
- * @param {Function} createSpec - Spec generation function (defaults to entitySpec)
- * @returns {Promise<string|Object>} Instructions string with specification property, or tuple if configured
+ * @param {Object} params - Parameters object
+ * @param {string} params.specification - Pre-generated entity specification
+ * @param {string} params.processing - Selection criteria (optional)
+ * @returns {string} Instructions string
  */
-export async function findInstructions(instructions, config = {}, createSpec = entitySpec) {
-  const { entities, processing } = instructions;
-  const { returnTuple, ...specConfig } = config;
-  const specification = await createSpec(entities, specConfig);
-
-  let combinedInstructions;
+export function findInstructions({ specification, processing }) {
   if (processing) {
-    combinedInstructions = `${asXML(processing, { tag: 'selection-criteria' })}
+    return `${asXML(processing, { tag: 'selection-criteria' })}
 
 ${FIND_PROCESS_STEPS}
 
 ${asXML(specification, { tag: 'entity-specification' })}`;
   } else {
-    combinedInstructions = `${DEFAULT_FIND_INSTRUCTIONS}
+    return `${DEFAULT_FIND_INSTRUCTIONS}
 
 ${asXML(specification, { tag: 'entity-specification' })}`;
   }
-
-  return createInstructionResult(combinedInstructions, specification, returnTuple);
 }
 
 /**
  * Create group instructions for entity extraction
- * @param {Object} instructions - Instructions object
- * @param {string} instructions.entities - What entities to extract
- * @param {string} instructions.processing - Grouping strategy (optional)
- * @param {Object} config - Configuration options
- * @param {boolean} config.returnTuple - Return {value, specification} instead of string with property
- * @param {Function} createSpec - Spec generation function (defaults to entitySpec)
- * @returns {Promise<string|Object>} Instructions string with specification property, or tuple if configured
+ * @param {Object} params - Parameters object
+ * @param {string} params.specification - Pre-generated entity specification
+ * @param {string} params.processing - Grouping strategy (optional)
+ * @returns {string} Instructions string
  */
-export async function groupInstructions(instructions, config = {}, createSpec = entitySpec) {
-  const { entities, processing } = instructions;
-  const { returnTuple, ...specConfig } = config;
-  const specification = await createSpec(entities, specConfig);
-
-  let combinedInstructions;
+export function groupInstructions({ specification, processing }) {
   if (processing) {
-    combinedInstructions = `${asXML(processing, { tag: 'grouping-strategy' })}
+    return `${asXML(processing, { tag: 'grouping-strategy' })}
 
 ${GROUP_PROCESS_STEPS}
 
 ${asXML(specification, { tag: 'entity-specification' })}`;
   } else {
-    combinedInstructions = `${DEFAULT_GROUP_INSTRUCTIONS}
+    return `${DEFAULT_GROUP_INSTRUCTIONS}
 
 ${asXML(specification, { tag: 'entity-specification' })}`;
   }
-
-  return createInstructionResult(combinedInstructions, specification, returnTuple);
 }
 
 // ===== Advanced Entity Functions =====

--- a/src/chains/entities/index.spec.js
+++ b/src/chains/entities/index.spec.js
@@ -89,68 +89,62 @@ Extraction Rules:
   });
 
   describe('instruction builders', () => {
-    it('should create map instructions', async () => {
+    it('should create map instructions', () => {
       const mockSpec = 'Entity specification';
-      chatGPT.mockResolvedValueOnce(mockSpec);
 
-      const instructions = await mapInstructions('Extract people');
+      const instructions = mapInstructions({ specification: mockSpec });
 
-      // Instructions are string-like objects with toString()
-      expect(instructions.toString()).toContain('Extract entities from each text chunk');
-      expect(instructions.specification).toBe(mockSpec);
+      expect(instructions).toContain('Extract entities from each text chunk');
+      expect(instructions).toContain(mockSpec);
     });
 
-    it('should create reduce instructions with custom processing', async () => {
+    it('should create reduce instructions with custom processing', () => {
       const mockSpec = 'Entity specification';
-      chatGPT.mockResolvedValueOnce(mockSpec);
 
-      const instructions = await reduceInstructions({
-        entities: 'Extract companies',
+      const instructions = reduceInstructions({
+        specification: mockSpec,
         processing: 'Merge all variations of company names',
       });
 
-      expect(instructions.toString()).toContain('Merge all variations of company names');
-      expect(instructions.toString()).toContain('Consolidate entities across text chunks');
-      expect(instructions.specification).toBe(mockSpec);
+      expect(instructions).toContain('Merge all variations of company names');
+      expect(instructions).toContain('Consolidate entities across text chunks');
+      expect(instructions).toContain(mockSpec);
     });
 
-    it('should create filter instructions', async () => {
+    it('should create filter instructions', () => {
       const mockSpec = 'Entity specification';
-      chatGPT.mockResolvedValueOnce(mockSpec);
 
-      const instructions = await filterInstructions({
-        entities: 'Extract locations',
+      const instructions = filterInstructions({
+        specification: mockSpec,
         processing: 'Keep entities in Europe',
       });
 
-      expect(instructions.toString()).toContain('Keep entities in Europe');
-      expect(instructions.toString()).toContain('filter');
+      expect(instructions).toContain('Keep entities in Europe');
+      expect(instructions).toContain('filter');
     });
 
-    it('should create find instructions', async () => {
+    it('should create find instructions', () => {
       const mockSpec = 'Entity specification';
-      chatGPT.mockResolvedValueOnce(mockSpec);
 
-      const instructions = await findInstructions({
-        entities: 'Extract all entities',
+      const instructions = findInstructions({
+        specification: mockSpec,
         processing: 'Find the most mentioned entity',
       });
 
-      expect(instructions.toString()).toContain('Find the most mentioned entity');
-      expect(instructions.toString()).toContain('selection-criteria');
+      expect(instructions).toContain('Find the most mentioned entity');
+      expect(instructions).toContain('selection-criteria');
     });
 
-    it('should create group instructions', async () => {
+    it('should create group instructions', () => {
       const mockSpec = 'Entity specification';
-      chatGPT.mockResolvedValueOnce(mockSpec);
 
-      const instructions = await groupInstructions({
-        entities: 'Extract organizations',
+      const instructions = groupInstructions({
+        specification: mockSpec,
         processing: 'Group by industry sector',
       });
 
-      expect(instructions.toString()).toContain('Group by industry sector');
-      expect(instructions.toString()).toContain('grouping-strategy');
+      expect(instructions).toContain('Group by industry sector');
+      expect(instructions).toContain('grouping-strategy');
     });
   });
 
@@ -163,6 +157,7 @@ Extraction Rules:
       expect(extractor.specification).toBe(spec);
 
       const mockEntities = { entities: [{ name: 'Test', type: 'test' }] };
+      // The extractor calls applyEntities which calls chatGPT once
       chatGPT.mockResolvedValueOnce(mockEntities);
 
       const result = await extractor('Test text');
@@ -180,29 +175,30 @@ Extraction Rules:
       expect(result.entities).toEqual([]);
     });
 
-    it('should handle backward compatibility for map instructions', async () => {
-      chatGPT.mockResolvedValueOnce('Spec');
+    it('should handle map instructions', () => {
+      const spec = 'Entity specification';
 
-      // String input (backward compatible)
-      const instructions1 = await mapInstructions('Extract companies');
-      expect(instructions1.toString()).toBeTruthy();
+      // Without processing
+      const instructions1 = mapInstructions({ specification: spec });
+      expect(instructions1).toBeTruthy();
+      expect(instructions1).toContain(spec);
 
-      // Object input
-      const instructions2 = await mapInstructions({
-        entities: 'Extract companies',
+      // With processing
+      const instructions2 = mapInstructions({
+        specification: spec,
         processing: 'Additional processing',
       });
-      expect(instructions2.toString()).toContain('Additional processing');
+      expect(instructions2).toContain('Additional processing');
+      expect(instructions2).toContain(spec);
     });
 
-    it('should return tuple when configured', async () => {
-      chatGPT.mockResolvedValueOnce('Test spec');
+    it('should create proper instructions', () => {
+      const spec = 'Test spec';
 
-      const result = await mapInstructions('Extract entities', { returnTuple: true });
+      const result = mapInstructions({ specification: spec });
 
-      expect(result).toHaveProperty('value');
-      expect(result).toHaveProperty('specification');
-      expect(result.specification).toBe('Test spec');
+      expect(result).toContain(spec);
+      expect(result).toContain('entity-specification');
     });
   });
 });

--- a/src/chains/relations/index.spec.js
+++ b/src/chains/relations/index.spec.js
@@ -183,81 +183,91 @@ describe('relations', () => {
 
   describe('instruction builders', () => {
     describe('mapInstructions', () => {
-      it('should create map instructions from string', async () => {
-        const instructions = await mapInstructions('Extract all relationships');
-        expect(instructions.specification).toBeTruthy();
-        expect(String(instructions)).toContain('relation-specification');
+      it('should create map instructions from string', () => {
+        const spec = 'Relation specification';
+        const instructions = mapInstructions({ specification: spec });
+        expect(instructions).toContain(spec);
+        expect(instructions).toContain('relation-specification');
       });
 
-      it('should handle complex instruction object', async () => {
-        const instructions = await mapInstructions({
-          relations: 'Extract business relationships',
+      it('should handle complex instruction object', () => {
+        const spec = 'Relation specification';
+        const instructions = mapInstructions({
+          specification: spec,
           processing: 'Focus on partnerships and acquisitions',
-          entities: [{ name: 'Apple', canonical: 'Apple Inc.' }],
         });
-        expect(instructions.specification).toBeTruthy();
-        expect(String(instructions)).toContain('relation-specification');
+        expect(instructions).toContain(spec);
+        expect(instructions).toContain('relation-specification');
+        expect(instructions).toContain('Focus on partnerships');
       });
 
-      it('should return tuple when configured', async () => {
-        const result = await mapInstructions('Extract relationships', { returnTuple: true });
-        expect(typeof result).toBe('object');
-        expect(result).toHaveProperty('value');
-        expect(result).toHaveProperty('specification');
-        expect(typeof result.value).toBe('string');
-        expect(typeof result.specification).toBe('string');
+      it('should create proper instructions', () => {
+        const spec = 'Relation specification';
+        const result = mapInstructions({ specification: spec });
+        expect(typeof result).toBe('string');
+        expect(result).toContain(spec);
+        expect(result).toContain('relation-specification');
       });
     });
 
     describe('filterInstructions', () => {
-      it('should create filter instructions', async () => {
-        const instructions = await filterInstructions({
-          relations: 'Extract employment relationships',
+      it('should create filter instructions', () => {
+        const spec = 'Relation specification';
+        const instructions = filterInstructions({
+          specification: spec,
           processing: 'Keep only C-level relationships',
         });
-        expect(instructions.specification).toBeTruthy();
-        expect(String(instructions)).toContain('relation-specification');
+        expect(instructions).toContain(spec);
+        expect(instructions).toContain('relation-specification');
+        expect(instructions).toContain('C-level relationships');
       });
     });
 
     describe('reduceInstructions', () => {
-      it('should create reduce instructions', async () => {
-        const instructions = await reduceInstructions({
-          relations: 'Extract all relationships',
+      it('should create reduce instructions', () => {
+        const spec = 'Relation specification';
+        const instructions = reduceInstructions({
+          specification: spec,
           processing: 'Build unified knowledge graph',
         });
-        expect(instructions.specification).toBeTruthy();
-        expect(String(instructions)).toContain('relation-specification');
+        expect(instructions).toContain(spec);
+        expect(instructions).toContain('relation-specification');
+        expect(instructions).toContain('unified knowledge graph');
       });
 
-      it('should use default processing when not provided', async () => {
-        const instructions = await reduceInstructions({
-          relations: 'Extract company relationships',
+      it('should use default processing when not provided', () => {
+        const spec = 'Relation specification';
+        const instructions = reduceInstructions({
+          specification: spec,
         });
-        expect(instructions.specification).toBeTruthy();
-        expect(String(instructions)).toContain('comprehensive relation graph');
+        expect(instructions).toContain(spec);
+        expect(instructions).toContain('comprehensive relation graph');
       });
     });
 
     describe('findInstructions', () => {
-      it('should create find instructions', async () => {
-        const instructions = await findInstructions({
-          relations: 'Extract conflict relationships',
+      it('should create find instructions', () => {
+        const spec = 'Relation specification';
+        const instructions = findInstructions({
+          specification: spec,
           processing: 'Find most contentious section',
         });
-        expect(instructions.specification).toBeTruthy();
-        expect(String(instructions)).toContain('relation-specification');
+        expect(instructions).toContain(spec);
+        expect(instructions).toContain('relation-specification');
+        expect(instructions).toContain('contentious section');
       });
     });
 
     describe('groupInstructions', () => {
-      it('should create group instructions', async () => {
-        const instructions = await groupInstructions({
-          relations: 'Extract all relationships',
+      it('should create group instructions', () => {
+        const spec = 'Relation specification';
+        const instructions = groupInstructions({
+          specification: spec,
           processing: 'Group by relationship type',
         });
-        expect(instructions.specification).toBeTruthy();
-        expect(String(instructions)).toContain('relation-specification');
+        expect(instructions).toContain(spec);
+        expect(instructions).toContain('relation-specification');
+        expect(instructions).toContain('relationship type');
       });
     });
   });

--- a/src/chains/scale/index.js
+++ b/src/chains/scale/index.js
@@ -120,167 +120,101 @@ export async function scaleItem(item, instructions, config = {}) {
 // ===== Instruction Builders =====
 
 /**
- * Helper to create instruction with attached specification
- * @param {string} instructions - The instruction string
- * @param {Object} specification - The specification object
- * @param {boolean} returnTuple - Whether to return as tuple
- * @returns {string|Object} Instructions with specification attached or tuple
- */
-function createInstructionResult(instructions, specification, returnTuple) {
-  if (returnTuple) {
-    return { value: instructions, specification };
-  }
-  // Attach specification as a property to the string
-  return Object.assign(instructions, { specification });
-}
-
-/**
  * Create map instructions for scaling
- * @param {string|Object} instructions - Scaling criteria string or instructions object
- * @param {string} instructions.scaling - How to scale each item
- * @param {string} instructions.processing - Additional processing instructions (optional)
- * @param {Object} config - Configuration options
- * @param {boolean} config.returnTuple - Return {value, specification} instead of string with property
- * @param {Function} createSpec - Spec generation function (defaults to scaleSpec)
- * @returns {Promise<string|Object>} Instructions string with specification property, or tuple if configured
+ * @param {Object} params - Parameters object
+ * @param {Object} params.specification - Pre-generated scale specification
+ * @param {string} params.processing - Additional processing instructions (optional)
+ * @returns {string} Instructions string
  */
-export async function mapInstructions(instructions, config = {}, createSpec = scaleSpec) {
-  // Handle backward compatibility - if instructions is a string, use it as scaling
-  const scaling = typeof instructions === 'string' ? instructions : instructions.scaling;
-  const processing = typeof instructions === 'object' ? instructions.processing : null;
-  const { returnTuple, ...specConfig } = config;
-  const specification = await createSpec(scaling, specConfig);
-
-  let combinedInstructions;
+export function mapInstructions({ specification, processing }) {
   if (processing) {
-    combinedInstructions = `${asXML(processing, { tag: 'processing-instructions' })}
+    return `${asXML(processing, { tag: 'processing-instructions' })}
 
 Apply this scale to transform each item:
 ${asXML(specification, { tag: 'scale-specification' })}`;
   } else {
-    combinedInstructions = `${DEFAULT_MAP_INSTRUCTIONS}
+    return `${DEFAULT_MAP_INSTRUCTIONS}
 
 ${asXML(specification, { tag: 'scale-specification' })}`;
   }
-
-  return createInstructionResult(combinedInstructions, specification, returnTuple);
 }
 
 /**
  * Create filter instructions for scaling
- * @param {Object} instructions - Instructions object
- * @param {string} instructions.scaling - How to scale each item
- * @param {string} instructions.processing - Filter criteria (optional - defaults based on scale midpoint)
- * @param {Object} config - Configuration options
- * @param {boolean} config.returnTuple - Return {value, specification} instead of string with property
- * @param {Function} createSpec - Spec generation function (defaults to scaleSpec)
- * @returns {Promise<string|Object>} Instructions string with specification property, or tuple if configured
+ * @param {Object} params - Parameters object
+ * @param {Object} params.specification - Pre-generated scale specification
+ * @param {string} params.processing - Filter criteria (optional - defaults based on scale midpoint)
+ * @returns {string} Instructions string
  */
-export async function filterInstructions(instructions, config = {}, createSpec = scaleSpec) {
-  const { scaling, processing } = instructions;
-  const { returnTuple, ...specConfig } = config;
-  const specification = await createSpec(scaling, specConfig);
-
-  let combinedInstructions;
+export function filterInstructions({ specification, processing }) {
   if (processing) {
-    combinedInstructions = `${asXML(processing, { tag: 'filter-criteria' })}
+    return `${asXML(processing, { tag: 'filter-criteria' })}
 
 ${FILTER_PROCESS_STEPS}
 
 ${asXML(specification, { tag: 'scale-specification' })}`;
   } else {
-    combinedInstructions = `${DEFAULT_FILTER_INSTRUCTIONS}
+    return `${DEFAULT_FILTER_INSTRUCTIONS}
 
 ${asXML(specification, { tag: 'scale-specification' })}`;
   }
-
-  return createInstructionResult(combinedInstructions, specification, returnTuple);
 }
 
 /**
  * Create reduce instructions for scaling
- * @param {Object} instructions - Instructions object
- * @param {string} instructions.scaling - How to scale each item
- * @param {string} instructions.processing - How to reduce the scaled values
- * @param {Object} config - Configuration options
- * @param {boolean} config.returnTuple - Return {value, specification} instead of string with property
- * @param {Function} createSpec - Spec generation function (defaults to scaleSpec)
- * @returns {Promise<string|Object>} Instructions string with specification property, or tuple if configured
+ * @param {Object} params - Parameters object
+ * @param {Object} params.specification - Pre-generated scale specification
+ * @param {string} params.processing - How to reduce the scaled values
+ * @returns {string} Instructions string
  */
-export async function reduceInstructions(instructions, config = {}, createSpec = scaleSpec) {
-  const { scaling, processing } = instructions;
-  const { returnTuple, ...specConfig } = config;
-  const specification = await createSpec(scaling, specConfig);
-
-  const combinedInstructions = `${asXML(processing, { tag: 'reduce-operation' })}
+export function reduceInstructions({ specification, processing }) {
+  return `${asXML(processing, { tag: 'reduce-operation' })}
 
 ${REDUCE_PROCESS_STEPS}
 
 ${asXML(specification, { tag: 'scale-specification' })}`;
-
-  return createInstructionResult(combinedInstructions, specification, returnTuple);
 }
 
 /**
  * Create find instructions for scaling
- * @param {Object} instructions - Instructions object
- * @param {string} instructions.scaling - How to scale each item
- * @param {string} instructions.processing - Selection criteria (optional - defaults to upper quartile)
- * @param {Object} config - Configuration options
- * @param {boolean} config.returnTuple - Return {value, specification} instead of string with property
- * @param {Function} createSpec - Spec generation function (defaults to scaleSpec)
- * @returns {Promise<string|Object>} Instructions string with specification property, or tuple if configured
+ * @param {Object} params - Parameters object
+ * @param {Object} params.specification - Pre-generated scale specification
+ * @param {string} params.processing - Selection criteria (optional - defaults to upper quartile)
+ * @returns {string} Instructions string
  */
-export async function findInstructions(instructions, config = {}, createSpec = scaleSpec) {
-  const { scaling, processing } = instructions;
-  const { returnTuple, ...specConfig } = config;
-  const specification = await createSpec(scaling, specConfig);
-
-  let combinedInstructions;
+export function findInstructions({ specification, processing }) {
   if (processing) {
-    combinedInstructions = `${asXML(processing, { tag: 'selection-criteria' })}
+    return `${asXML(processing, { tag: 'selection-criteria' })}
 
 ${FIND_PROCESS_STEPS}
 
 ${asXML(specification, { tag: 'scale-specification' })}`;
   } else {
-    combinedInstructions = `${DEFAULT_FIND_INSTRUCTIONS}
+    return `${DEFAULT_FIND_INSTRUCTIONS}
 
 ${asXML(specification, { tag: 'scale-specification' })}`;
   }
-
-  return createInstructionResult(combinedInstructions, specification, returnTuple);
 }
 
 /**
  * Create group instructions for scaling
- * @param {Object} instructions - Instructions object
- * @param {string} instructions.scaling - How to scale each item
- * @param {string} instructions.processing - Grouping strategy (optional - defaults to ranges)
- * @param {Object} config - Configuration options
- * @param {boolean} config.returnTuple - Return {value, specification} instead of string with property
- * @param {Function} createSpec - Spec generation function (defaults to scaleSpec)
- * @returns {Promise<string|Object>} Instructions string with specification property, or tuple if configured
+ * @param {Object} params - Parameters object
+ * @param {Object} params.specification - Pre-generated scale specification
+ * @param {string} params.processing - Grouping strategy (optional - defaults to ranges)
+ * @returns {string} Instructions string
  */
-export async function groupInstructions(instructions, config = {}, createSpec = scaleSpec) {
-  const { scaling, processing } = instructions;
-  const { returnTuple, ...specConfig } = config;
-  const specification = await createSpec(scaling, specConfig);
-
-  let combinedInstructions;
+export function groupInstructions({ specification, processing }) {
   if (processing) {
-    combinedInstructions = `${asXML(processing, { tag: 'grouping-strategy' })}
+    return `${asXML(processing, { tag: 'grouping-strategy' })}
 
 ${GROUP_PROCESS_STEPS}
 
 ${asXML(specification, { tag: 'scale-specification' })}`;
   } else {
-    combinedInstructions = `${DEFAULT_GROUP_INSTRUCTIONS}
+    return `${DEFAULT_GROUP_INSTRUCTIONS}
 
 ${asXML(specification, { tag: 'scale-specification' })}`;
   }
-
-  return createInstructionResult(combinedInstructions, specification, returnTuple);
 }
 
 // ===== Advanced Scale Functions =====

--- a/src/chains/score/index.spec.js
+++ b/src/chains/score/index.spec.js
@@ -77,7 +77,7 @@ describe('score chain', () => {
   describe('scoreItem', () => {
     it('scores a single item', async () => {
       scaleSpec.mockResolvedValueOnce(mockSpec);
-      chatGPT.mockResolvedValueOnce({ score: 7 });
+      chatGPT.mockResolvedValueOnce(7); // chatGPT auto-unwraps single value property
 
       const result = await scoreItem('test item', 'score by length');
 
@@ -92,7 +92,7 @@ describe('score chain', () => {
 
   describe('applyScore', () => {
     it('applies a score specification to a single item', async () => {
-      chatGPT.mockResolvedValueOnce({ score: 7 });
+      chatGPT.mockResolvedValueOnce(7); // chatGPT auto-unwraps single value property
 
       const result = await applyScore('test item', mockSpec);
 
@@ -106,96 +106,63 @@ describe('score chain', () => {
 
   describe('instruction builders', () => {
     describe('mapInstructions', () => {
-      it('creates map instructions with specification attached', async () => {
-        scaleSpec.mockResolvedValueOnce(mockSpec);
+      it('creates map instructions from specification', () => {
+        const instructions = mapInstructions({ specification: mockSpec });
 
-        const instructions = await mapInstructions('score by length');
-
-        expect(instructions.specification).toEqual(mockSpec);
-        expect(String(instructions)).toContain('score-specification');
-        expect(String(instructions)).toContain('Return ONLY the score value');
-      });
-
-      it('returns tuple when configured', async () => {
-        scaleSpec.mockResolvedValueOnce(mockSpec);
-
-        const result = await mapInstructions('score by length', { returnTuple: true });
-
-        expect(result.value).toContain('score-specification');
-        expect(result.specification).toEqual(mockSpec);
-      });
-
-      it('accepts custom spec generator', async () => {
-        const customSpec = vi.fn().mockResolvedValueOnce(mockSpec);
-
-        await mapInstructions('score by length', {}, customSpec);
-
-        expect(customSpec).toHaveBeenCalledWith('score by length', {});
-        expect(scaleSpec).not.toHaveBeenCalled();
+        expect(instructions).toContain('score-specification');
+        expect(instructions).toContain('Return ONLY the score value');
       });
     });
 
     describe('filterInstructions', () => {
-      it('creates filter instructions with specification attached', async () => {
-        scaleSpec.mockResolvedValueOnce(mockSpec);
-
-        const instructions = await filterInstructions({
-          scoring: 'score by quality',
+      it('creates filter instructions from specification', () => {
+        const instructions = filterInstructions({
+          specification: mockSpec,
           processing: 'keep scores above 7',
         });
 
-        expect(instructions.specification).toEqual(mockSpec);
-        expect(String(instructions)).toContain('score-specification');
-        expect(String(instructions)).toContain('filter-condition');
-        expect(String(instructions)).toContain('keep scores above 7');
+        expect(instructions).toContain('score-specification');
+        expect(instructions).toContain('filter-condition');
+        expect(instructions).toContain('keep scores above 7');
       });
     });
 
     describe('reduceInstructions', () => {
-      it('creates reduce instructions with specification attached', async () => {
-        scaleSpec.mockResolvedValueOnce(mockSpec);
-
-        const instructions = await reduceInstructions({
-          scoring: 'score by relevance',
+      it('creates reduce instructions from specification', () => {
+        const instructions = reduceInstructions({
+          specification: mockSpec,
           processing: 'sum all scores',
         });
 
-        expect(instructions.specification).toEqual(mockSpec);
-        expect(String(instructions)).toContain('score-specification');
-        expect(String(instructions)).toContain('reduce-operation');
-        expect(String(instructions)).toContain('sum all scores');
+        expect(instructions).toContain('score-specification');
+        expect(instructions).toContain('reduce-operation');
+        expect(instructions).toContain('sum all scores');
       });
     });
 
     describe('findInstructions', () => {
-      it('creates find instructions with specification attached', async () => {
-        scaleSpec.mockResolvedValueOnce(mockSpec);
-
-        const instructions = await findInstructions({
-          scoring: 'score by match',
+      it('creates find instructions from specification', () => {
+        const instructions = findInstructions({
+          specification: mockSpec,
           processing: 'highest scoring item',
         });
 
-        expect(instructions.specification).toEqual(mockSpec);
-        expect(String(instructions)).toContain('score-specification');
-        expect(String(instructions)).toContain('selection-criteria');
-        expect(String(instructions)).toContain('highest scoring item');
+        expect(instructions).toContain('score-specification');
+        expect(instructions).toContain('selection-criteria');
+        expect(instructions).toContain('highest scoring item');
       });
     });
 
     describe('groupInstructions', () => {
-      it('creates group instructions with specification attached', async () => {
-        scaleSpec.mockResolvedValueOnce(mockSpec);
-
-        const instructions = await groupInstructions({
-          scoring: 'score by category',
+      it('creates group instructions from specification', () => {
+        const instructions = groupInstructions({
+          specification: mockSpec,
           processing: 'group into low, medium, high',
         });
 
-        expect(instructions.specification).toEqual(mockSpec);
-        expect(String(instructions)).toContain('score-specification');
-        expect(String(instructions)).toContain('grouping-strategy');
-        expect(String(instructions)).toContain('group into low, medium, high');
+        expect(instructions).toContain('score-specification');
+        expect(instructions).toContain('grouping-strategy');
+        expect(instructions).toContain('group into low, medium, high');
       });
     });
   });
@@ -276,10 +243,9 @@ describe('score chain', () => {
 
   describe('integration with collection chains', () => {
     it('can use mapInstructions with map chain', async () => {
-      scaleSpec.mockResolvedValueOnce(mockSpec);
       map.mockResolvedValueOnce(['5', '7', '3']);
 
-      const instructions = await mapInstructions('score by quality');
+      const instructions = mapInstructions({ specification: mockSpec });
       const items = ['item1', 'item2', 'item3'];
 
       const scores = await map(items, instructions);
@@ -289,11 +255,10 @@ describe('score chain', () => {
     });
 
     it('can use filterInstructions with filter chain', async () => {
-      scaleSpec.mockResolvedValueOnce(mockSpec);
       filter.mockResolvedValueOnce(['item1', 'item3']);
 
-      const instructions = await filterInstructions({
-        scoring: 'score by relevance',
+      const instructions = filterInstructions({
+        specification: mockSpec,
         processing: 'keep scores above 5',
       });
       const items = ['item1', 'item2', 'item3'];

--- a/src/chains/score/score-single-result.json
+++ b/src/chains/score/score-single-result.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "value": {
+      "type": "number",
+      "description": "The numeric score value that represents the evaluation of the item according to the provided specification. This value must fall within the range defined by the score specification. The score should accurately reflect how well the item meets the criteria outlined in the specification, with higher values indicating better alignment with the desired qualities and lower values indicating poorer alignment."
+    }
+  },
+  "required": ["value"],
+  "additionalProperties": false
+}


### PR DESCRIPTION

## Overview

  Refactored 5 chain modules to eliminate redundant async spec
  generation in instruction builders and remove unnecessary abstraction
  layers, improving code clarity and performance.

## Changes

  Core Refactoring Pattern Applied

  - Removed createModelOptions helper - Inline response_format
  configuration directly
  - Made all instruction builders synchronous - Moved async spec
  generation to orchestration level
  - Standardized API - All instruction builders now accept { 
  specification, processing } parameters
  - Removed createInstructionResult helper - Eliminated unnecessary
  string-to-object wrapping

## Modules Refactored

  1. Score Chain (src/chains/score/)
  - Removed createModelOptions function
  - Made mapInstructions, filterInstructions, reduceInstructions,
  findInstructions, groupInstructions synchronous
  - Created score-single-result.json schema file
  - Updated scoreItem and mapScore to generate specs once

  2. Scale Chain (src/chains/scale/)
  - Applied same refactoring pattern as score chain
  - Made all 5 instruction builders synchronous
  - Removed redundant helper functions

  3. Anonymize Chain (src/chains/anonymize/)
  - Removed createInstructionResult helper
  - Made all instruction builders synchronous
  - Simplified instruction generation logic

  4. Entities Chain (src/chains/entities/)
  - Made all instruction builders synchronous
  - Removed async spec generation from collection operations
  - Created entity-result.json schema file

  5. Relations Chain (src/chains/relations/)
  - Applied same refactoring pattern
  - Made all instruction builders synchronous
  - Simplified instruction generation
