### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@far-world-labs/verblets",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@far-world-labs/verblets",
-      "version": "0.6.4",
+      "version": "0.7.0",
       "license": "All Rights Reserved",
       "dependencies": {
         "acorn": "^8.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@far-world-labs/verblets",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Verblets is a collection of tools for building LLM-powered applications.",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary

- Version bump from 0.6.4 → 0.7.0

## Release Notes (v0.7.0)

### Highlights

- **Instruction-as-context** — Every chain and verblet accepts structured instruction bundles (`{ text, ...namedContext }`). Unknown keys become XML context prepended to prompts; known keys (`spec`, `anchors`, `categories`, `vocabulary`, etc.) override internal derivation, skipping expensive LLM calls. Enables pipeline patterns where one chain's derived artifacts feed the next.
- **Semantic state system** (`sem.*`) — 9-function API for constructing and querying semantic state: `define`, `fragment`, `refine` (LLM chains), `ingest`, `match` (embed), `planRead`, `read`/`readDetails`, `shapeState` (pure math). Projection-shaped fragments compose into vector-bearing states with scalar readouts.
- **Multimodal embedding** — CLIP-based image and text embedding in a shared vector space. `embedImage`/`embedImageBatch` for images; `sem.ingest` auto-routes image fragments through the multimodal model. Rule-based `EmbeddingService` negotiation parallel to `ModelService`.
- **Artifact capture** — `collectEventsWith(fn, ...fields)` wraps a chain call and captures derived artifacts (specs, anchors, categories) from progress events, returning `[result, captured]` for pipeline reuse.

### New APIs

- `resolveTexts(instruction, knownKeys)` / `resolveArgs(instructions, config, knownKeys)` — instruction normalization (lib/instruction)
- `ContextBudget` — lightweight XML context assembler: collect, wrap, join (lib/context-budget)
- `collectEventsWith(fn, ...fields)` — progress event capture returning `[result, captured]` tuple (lib/collect-events-with)
- `templateBuilder` / `slot()` — immutable tagged-template prompt builder with named slots (lib/template-builder)
- `sem.define`, `sem.fragment`, `sem.refine`, `sem.ingest`, `sem.match`, `sem.planRead`, `sem.read`, `sem.readDetails`, `sem.shapeState` — semantic state construction and query
- `EmbeddingService` — rule-based embedding model negotiation with CLIP multimodal default
- `embedImage` / `embedImageBatch` — CLIP image embedding
- `scoreChunksByProbes` — embedding-based chunk scoring against probe vectors
- `scoreInstructions({ spec, anchors })` — instruction bundle builder for score chain
- `calibrateInstructions({ spec })` — instruction bundle builder for calibrate chain
- `tagInstructions({ spec, vocabulary })` — instruction bundle builder for tags chain
- `createTagger(vocabulary)` / `createTagExtractor(spec, vocabulary)` — vocabulary-bound tag factories
- `fn.knownTexts` — static property on every chain/verblet listing recognized instruction keys

### Breaking Changes

- `buildInstructions` factory removed — replaced by `resolveTexts` in each chain
- Spec chains (entities, score, tags, scale, relations, calibrate) accept `spec`/`anchors` via instruction bundles instead of `config.spec`
- Default embedding model changed from mxbai-embed-xsmall (384-dim) to CLIP (512-dim)
- All embed module paths moved from `src/lib/embed/` to `src/embed/`
- Probe interface simplified: `{ category, label, queries: string[] }` → `{ category, label, query: string }`
- `MODEL_KEYS` and `EMBED_CAPABILITY_KEYS` no longer exported from shared.js
- `CENTRAL_TENDENCY_PROMPT` renamed to `CENTRAL_TENDENCY_CORE`

### Fixed

- OpenAI provider: translate camelCase `responseFormat` to snake_case `response_format`
- LLM module: fall back to singleton `defaultModelService` when `options.modelService` is undefined
- SummaryMap: `model.maxTokens` → `model.maxOutputTokens` (property renamed in catalog)
- to-object: handle already-parsed JSON from `responseFormat` in `parseAndValidate`
- 6 prompt-shaping mapper fixes: `mapDepth`, `mapDivergence`, `mapAbstraction`, `mapGranularity`, `mapCreativity`, `mapTolerance` — now correctly pass through unrecognized string values
- Null rejection at instruction boundary — `resolveArgs`/`normalizeInstruction` throw on null input
- AbortSignal threading through embedding pipeline (`embedBatch` → `embedChunked` → `embedScore` → `probeScan`)

### Removed

- `buildInstructions` factory (replaced by per-chain `resolveTexts`)
- `probe-scan` chain (replaced by `src/embed/score-chunks-by-probes`)
- `embed-probes` lib module (inlined into consuming chains)
- Dead code: `documentationCoverage.js`, `model-definition-schema.json`, `cars-test.json`, `bool/index.schema.json`, `scan-file.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)