### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@far-world-labs/verblets",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@far-world-labs/verblets",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "All Rights Reserved",
       "dependencies": {
         "acorn": "^8.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@far-world-labs/verblets",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Verblets is a collection of tools for building LLM-powered applications.",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary
Minor bump after #221 landed. Version bump triggers the release workflow to publish to npm and create the `v0.8.0` tag.

Why minor and not patch: the score-matrix PR included rename-style breaking changes for callers of `extractEntities` / `extractRelations` / `peopleList` / `popReference` and the `mapXxxBatched` aliases. Pre-1.0 semver conventionally treats those as minor.

## Test plan
- [x] CI green on the bump branch
- [ ] After merge, release workflow publishes 0.8.0 to npm and tags v0.8.0