### PR TITLE
Table-driven examples-runner + LlmMockResponse factories (pilot)

### DIFF
--- a/.claude/guidelines/unit-tests.md
+++ b/.claude/guidelines/unit-tests.md
@@ -6,6 +6,37 @@
 - **Use realistic mock responses** - Match actual LLM output formats
 - **Avoid mocking fs in most cases** - Use real file system operations for simpler, more reliable tests
 
+## Preferred shape: table-driven via `runTable`
+
+New specs should use the table-driven runner in `src/lib/examples-runner/` and the fishery factory families in `src/lib/test-utils/factories/`. The `inventory.json` in `.claude/spec/test-inventory/` lists every existing spec and its proposed table group; migrations land module by module.
+
+```js
+import { runTable } from '../../lib/examples-runner/index.js';
+import { popReferenceVariants } from '../../lib/test-utils/factories/pop-reference.js';
+
+const examples = [
+  { name: 'returns the references the LLM produced', inputs: {...}, want: 1 },
+  { name: 'throws on null', inputs: { mockResponse: popReferenceVariants.isNull }, want: { throws: 'object' } },
+];
+
+runTable({ describe: 'popReferenceItem: result count', examples, process });
+```
+
+- **`want`** can be a literal value (deep-equal), a function `(varied) => expected` (called per row when `vary` expands), `{ throws: true | string | RegExp }`, or `{ eq: <ref> }` for identity equality.
+- **`vary`** (optional) declares cross-product axes; `expandExamples` turns one row into N. `inputs` and `want` may also be functions that receive the varied combo.
+- Imperative `it()` blocks remain valid for assertions that don't reduce to want/got compare (e.g. asserting prompt content includes a fragment, or that a mock was called N times). Mix patterns within a file when natural — don't force every assertion into the table.
+
+Reference migrations: `src/lib/pave/index.spec.js` (pure utility) and `src/chains/pop-reference/index.spec.js` (LLM-backed chain).
+
+## Mock factories
+
+Use the fishery-based factory families (`src/lib/test-utils/factories/`) for LLM mock responses, scan-shaped fixtures, and progress-event fixtures. Each chain factory exposes the same variant vocabulary:
+
+- `wellFormed`, `empty`, `isNull`, `undefinedValue`, `malformedShape`, `rejected`
+- `undersized`, `oversized` (when the response shape contains an array)
+
+Don't force a common payload base — chains have different well-formed shapes (`{ references: [...] }`, `{ value: number }`, etc.). Variant *names* align across chains; payload structures stay native to the chain.
+
 ## Test Organization
 - Group tests by input characteristics (clear vs ambiguous)
 - Use descriptive test names that specify expected behavior

--- a/.claude/guidelines/unit-tests.md
+++ b/.claude/guidelines/unit-tests.md
@@ -22,9 +22,16 @@ const examples = [
 runTable({ describe: 'popReferenceItem: result count', examples, process });
 ```
 
-- **`want`** can be a literal value (deep-equal), a function `(varied) => expected` (called per row when `vary` expands), `{ throws: true | string | RegExp }`, or `{ eq: <ref> }` for identity equality.
+- **`want`** matchers (combine freely except `throws`, which is exclusive):
+  - literal value: deep-equal via `toEqual`
+  - function `(varied) => expected`: called per row when `vary` expands, then deep-equal
+  - `{ throws: true | string | RegExp }`: assert sync/async throw, optionally match the message
+  - `{ eq: ref }`: identity equality via `toBe`
+  - `{ contains: x }`: `toContain` (substring, array element, set member)
+  - `{ matches: 'sub' | /re/ }`: `toMatch`
+  - `{ partial: {...} }`: `toMatchObject` for asserting only specific fields of a complex result
 - **`vary`** (optional) declares cross-product axes; `expandExamples` turns one row into N. `inputs` and `want` may also be functions that receive the varied combo.
-- Imperative `it()` blocks remain valid for assertions that don't reduce to want/got compare (e.g. asserting prompt content includes a fragment, or that a mock was called N times). Mix patterns within a file when natural — don't force every assertion into the table.
+- **Distill assertions into the processor's return.** Most "imperative-only" tests collapse: a processor that returns `{ length, outcome, schemaName }` plus `want: { partial: {...} }` covers compound assertions cleanly. Reserve raw `it()` blocks for cases that genuinely don't reduce to want/got compare.
 
 Reference migrations: `src/lib/pave/index.spec.js` (pure utility) and `src/chains/pop-reference/index.spec.js` (LLM-backed chain).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-unicorn": "^59.0.1",
         "eslint-plugin-vitest": "^0.5.4",
+        "fishery": "^2.4.0",
         "husky": "^8.0.3",
         "install-peerdeps": "^3.0.3",
         "jsdom": "^26.1.0",
@@ -7423,6 +7424,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fishery": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/fishery/-/fishery-2.4.0.tgz",
+      "integrity": "sha512-QgeTlvgNhVGuMztrfAhlSIBs3rD3l9RMjl9I15yb/lnrx3njrOhvegr2L3LWdqvXwYfQjdQGpglyAfHH2J8DRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.mergewith": "^4.6.2"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "license": "BSD-3-Clause",
@@ -9576,6 +9587,13 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-unicorn": "^59.0.1",
     "eslint-plugin-vitest": "^0.5.4",
+    "fishery": "^2.4.0",
     "husky": "^8.0.3",
     "install-peerdeps": "^3.0.3",
     "jsdom": "^26.1.0",

--- a/src/chains/pop-reference/index.spec.js
+++ b/src/chains/pop-reference/index.spec.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, vi } from 'vitest';
 import popReferenceItem, { mapPopReference, mapPopReferenceParallel } from './index.js';
 import {
   popReferenceVariants,
@@ -27,7 +27,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-// ─── popReferenceItem result-shape table ──────────────────────────────────
+// ─── popReferenceItem: result-shape table ─────────────────────────────────
 //
 // Each row stages an LLM response via the pop-reference factory variants
 // (or `popReferenceWithCount` for arbitrary sizes) and asserts on the count
@@ -84,92 +84,174 @@ runTable({
   process: itemCountProcessor,
 });
 
-// ─── popReferenceItem prompt construction ─────────────────────────────────
+// ─── popReferenceItem: prompt construction ────────────────────────────────
 //
-// Prompt-shape assertions don't fit the want/got compare cleanly — they
-// inspect call args, not return values. Kept imperative.
+// The processor returns the prompt that went to the LLM; `want.contains`
+// asserts substring presence, no imperative scaffolding required.
 
-describe('popReferenceItem: prompt construction', () => {
-  it('mentions sources when include is provided', async () => {
-    llm.mockResolvedValue(popReferenceVariants.wellFormed());
-    await popReferenceItem('any sentence', 'desc', { include: ['The Office'] });
-    expect(llm).toHaveBeenCalledWith(expect.stringContaining('<sources>'), expect.any(Object));
-  });
+const promptExamples = [
+  {
+    name: 'mentions sources when include is provided',
+    inputs: { options: { include: ['The Office'] } },
+    want: { contains: '<sources>' },
+  },
+  {
+    name: 'formats weighted sources with focus percentage',
+    inputs: {
+      options: {
+        include: [
+          { reference: 'Internet Memes', percent: 80 },
+          { reference: 'The Office', percent: 20 },
+        ],
+      },
+    },
+    want: { contains: 'Internet Memes (focus 80%)' },
+  },
+  {
+    name: 'respects referencesPerSource',
+    inputs: { options: { referencesPerSource: 3 } },
+    want: { contains: 'Find 3 references per source' },
+  },
+];
 
-  it('formats weighted sources with focus percentage', async () => {
-    llm.mockResolvedValue(popReferenceVariants.wellFormed());
-    await popReferenceItem('any sentence', 'desc', {
-      include: [
-        { reference: 'Internet Memes', percent: 80 },
-        { reference: 'The Office', percent: 20 },
-      ],
-    });
-    expect(llm).toHaveBeenCalledWith(
-      expect.stringContaining('Internet Memes (focus 80%)'),
-      expect.any(Object)
-    );
-  });
+const promptProcessor = async ({ options }) => {
+  llm.mockResolvedValue(popReferenceVariants.wellFormed());
+  await popReferenceItem('any sentence', 'desc', options);
+  return llm.mock.calls[0][0];
+};
 
-  it('respects referencesPerSource', async () => {
-    llm.mockResolvedValue(popReferenceVariants.wellFormed());
-    await popReferenceItem('any sentence', 'desc', { referencesPerSource: 3 });
-    expect(llm).toHaveBeenCalledWith(
-      expect.stringContaining('Find 3 references per source'),
-      expect.any(Object)
-    );
-  });
+runTable({
+  describe: 'popReferenceItem: prompt construction',
+  examples: promptExamples,
+  process: promptProcessor,
 });
 
 // ─── mapPopReferenceParallel ──────────────────────────────────────────────
+//
+// Compound assertions distill into a structured shape — `want.partial`
+// matches only the fields we care about.
 
-describe('mapPopReferenceParallel', () => {
-  it('runs popReferenceItem per sentence with one shared description', async () => {
-    llm
-      .mockResolvedValueOnce(popReferenceWithCount(1))
-      .mockResolvedValueOnce(popReferenceVariants.empty());
-    const result = await mapPopReferenceParallel(['s1', 's2'], 'shared description');
-    expect(result).toHaveLength(2);
-    expect(result[0]).toHaveLength(1);
-    expect(result[1]).toEqual([]);
-    expect(llm).toHaveBeenCalledTimes(2);
-  });
+const parallelExamples = [
+  {
+    name: 'runs popReferenceItem per sentence with one shared description',
+    inputs: {
+      sentences: ['s1', 's2'],
+      description: 'shared description',
+      options: undefined,
+      mockResponses: [() => popReferenceWithCount(1), () => popReferenceVariants.empty()],
+    },
+    want: {
+      partial: {
+        length: 2,
+        firstLength: 1,
+        secondLength: 0,
+        callCount: 2,
+      },
+    },
+  },
+  {
+    name: 'reports partial outcome when one sentence fails',
+    inputs: {
+      sentences: ['ok', 'bad'],
+      description: 'desc',
+      options: { maxAttempts: 1 },
+      mockResponses: [() => popReferenceVariants.empty(), popReferenceVariants.rejected],
+    },
+    want: {
+      partial: {
+        firstLength: 0,
+        secondUndefined: true,
+        outcome: 'partial',
+      },
+    },
+  },
+  {
+    name: 'throws when sentences is not an array',
+    inputs: {
+      sentences: 'not-an-array',
+      description: 'd',
+      options: undefined,
+      mockResponses: [],
+    },
+    want: { throws: 'must be an array' },
+  },
+];
 
-  it('reports partial outcome when one sentence fails', async () => {
-    llm
-      .mockResolvedValueOnce(popReferenceVariants.empty())
-      .mockRejectedValueOnce(new Error('boom'));
-    const events = [];
-    const result = await mapPopReferenceParallel(['ok', 'bad'], 'desc', {
-      maxAttempts: 1,
-      onProgress: (e) => events.push(e),
-    });
-    expect(result[0]).toEqual([]);
-    expect(result[1]).toBeUndefined();
-    const complete = events.find(
-      (e) => e.event === 'chain:complete' && e.step === 'pop-reference:parallel'
-    );
-    expect(complete.outcome).toBe('partial');
+const parallelProcessor = async ({ sentences, description, options, mockResponses }) => {
+  for (const make of mockResponses) {
+    if (make === popReferenceVariants.rejected) {
+      llm.mockRejectedValueOnce(new Error('boom'));
+    } else {
+      llm.mockResolvedValueOnce(make());
+    }
+  }
+  const events = [];
+  const result = await mapPopReferenceParallel(sentences, description, {
+    ...options,
+    onProgress: (e) => events.push(e),
   });
+  const complete = events.find(
+    (e) => e.event === 'chain:complete' && e.step === 'pop-reference:parallel'
+  );
+  return {
+    length: result.length,
+    firstLength: result[0]?.length ?? 0,
+    secondLength: result[1]?.length ?? 0,
+    secondUndefined: result[1] === undefined,
+    callCount: llm.mock.calls.length,
+    outcome: complete?.outcome,
+  };
+};
 
-  it('throws when sentences is not an array', async () => {
-    await expect(mapPopReferenceParallel('not-an-array', 'd')).rejects.toThrow(/must be an array/);
-  });
+runTable({
+  describe: 'mapPopReferenceParallel',
+  examples: parallelExamples,
+  process: parallelProcessor,
 });
 
 // ─── mapPopReference (batched) ────────────────────────────────────────────
 
-describe('mapPopReference (batched)', () => {
-  it('routes through map() with the pop-reference batch responseFormat', async () => {
-    vi.mocked(map).mockResolvedValueOnce([popReferenceWithCount(1), popReferenceVariants.empty()]);
-    const result = await mapPopReference(['s1', 's2'], 'description');
-    expect(result).toHaveLength(2);
-    expect(result[0][0].reference).toBeTruthy();
-    expect(result[1]).toEqual([]);
-    const mapConfig = vi.mocked(map).mock.calls[0][2];
-    expect(mapConfig.responseFormat?.json_schema?.name).toBe('pop_reference_batch');
-  });
+const batchedExamples = [
+  {
+    name: 'routes through map() with the pop-reference batch responseFormat',
+    inputs: {
+      sentences: ['s1', 's2'],
+      description: 'description',
+      mapResults: [popReferenceWithCount(1), popReferenceVariants.empty()],
+    },
+    want: {
+      partial: {
+        length: 2,
+        firstHasReference: true,
+        secondLength: 0,
+        schemaName: 'pop_reference_batch',
+      },
+    },
+  },
+  {
+    name: 'throws when sentences is not an array',
+    inputs: {
+      sentences: 'not-an-array',
+      description: 'd',
+      mapResults: [],
+    },
+    want: { throws: 'must be an array' },
+  },
+];
 
-  it('throws when sentences is not an array', async () => {
-    await expect(mapPopReference('not-an-array', 'd')).rejects.toThrow(/must be an array/);
-  });
+const batchedProcessor = async ({ sentences, description, mapResults }) => {
+  vi.mocked(map).mockResolvedValueOnce(mapResults);
+  const result = await mapPopReference(sentences, description);
+  return {
+    length: result.length,
+    firstHasReference: !!result[0]?.[0]?.reference,
+    secondLength: result[1]?.length ?? 0,
+    schemaName: vi.mocked(map).mock.calls[0]?.[2]?.responseFormat?.json_schema?.name,
+  };
+};
+
+runTable({
+  describe: 'mapPopReference (batched)',
+  examples: batchedExamples,
+  process: batchedProcessor,
 });

--- a/src/chains/pop-reference/index.spec.js
+++ b/src/chains/pop-reference/index.spec.js
@@ -1,233 +1,132 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import popReferenceItem, { mapPopReference, mapPopReferenceParallel } from './index.js';
+import {
+  popReferenceVariants,
+  popReferenceWithCount,
+} from '../../lib/test-utils/factories/pop-reference.js';
+import { runTable } from '../../lib/examples-runner/index.js';
 import llm from '../../lib/llm/index.js';
 import map from '../map/index.js';
 
-vi.mock('../../lib/parallel-batch/index.js', () => ({
-  default: vi.fn(async (items, processor) => {
-    for (let i = 0; i < items.length; i++) {
-      await processor(items[i], i);
-    }
-  }),
-}));
+// ─── mocks ────────────────────────────────────────────────────────────────
 
-vi.mock('../map/index.js', () => ({
-  default: vi.fn(),
-}));
-
-// Mock dependencies
 vi.mock('../../lib/llm/index.js', () => ({
   default: vi.fn(),
   jsonSchema: (name, schema) => ({ type: 'json_schema', json_schema: { name, schema } }),
 }));
 
-// Mock fs/promises for schema loading
-vi.mock('node:fs/promises', () => ({
-  default: {
-    readFile: vi.fn().mockResolvedValue(
-      JSON.stringify({
-        type: 'object',
-        properties: {
-          references: {
-            type: 'array',
-            items: { type: 'object' },
-          },
-        },
-        required: ['references'],
-        additionalProperties: false,
-      })
-    ),
-  },
-  readFile: vi.fn().mockResolvedValue(
-    JSON.stringify({
-      type: 'object',
-      properties: {
-        references: {
-          type: 'array',
-          items: { type: 'object' },
-        },
-      },
-      required: ['references'],
-      additionalProperties: false,
-    })
-  ),
+vi.mock('../map/index.js', () => ({ default: vi.fn() }));
+
+vi.mock('../../lib/parallel-batch/index.js', () => ({
+  default: vi.fn(async (items, processor) => {
+    for (let i = 0; i < items.length; i++) await processor(items[i], i);
+  }),
 }));
 
-describe('popReferenceItem', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
-  it('should find pop culture references for a sentence', async () => {
-    const mockResponse = {
-      references: [
-        {
-          reference: 'when Neo takes the red pill',
-          source: 'The Matrix',
-          context: 'he chooses uncomfortable truth over comforting illusion',
-          score: 0.88,
-          match: {
-            text: 'finally made a decision',
-            start: 12,
-            end: 35,
-          },
-        },
-      ],
-    };
+// ─── popReferenceItem result-shape table ──────────────────────────────────
+//
+// Each row stages an LLM response via the pop-reference factory variants
+// (or `popReferenceWithCount` for arbitrary sizes) and asserts on the count
+// the chain returns. Variant naming aligns with the project-wide vocabulary
+// in src/lib/test-utils/factories/variants.js.
 
-    llm.mockResolvedValue(mockResponse);
+const itemCountExamples = [
+  {
+    name: 'returns each reference the LLM produced (single)',
+    inputs: { mockResponse: () => popReferenceWithCount(1) },
+    want: 1,
+  },
+  {
+    name: 'returns each reference the LLM produced (many)',
+    inputs: { mockResponse: () => popReferenceWithCount(5) },
+    want: 5,
+  },
+  {
+    name: 'returns empty array when the LLM finds nothing',
+    inputs: { mockResponse: popReferenceVariants.empty },
+    want: 0,
+  },
+  {
+    name: 'throws when the LLM returns null',
+    inputs: { mockResponse: popReferenceVariants.isNull },
+    want: { throws: 'object' },
+  },
+  {
+    name: 'throws when the LLM returns a malformed shape',
+    inputs: { mockResponse: popReferenceVariants.malformedShape },
+    want: { throws: 'array' },
+  },
+  {
+    name: 'throws on empty sentence (boundary validation)',
+    inputs: { sentence: '', mockResponse: popReferenceVariants.wellFormed },
+    want: { throws: 'sentence must be a non-empty string' },
+  },
+];
 
-    const result = await popReferenceItem(
-      'She finally made a decision after months of doubt',
-      'pivotal moment of choosing clarity over comfort'
-    );
+const itemCountProcessor = async ({
+  sentence = 'She finally made a decision',
+  description = 'pivotal moment',
+  options,
+  mockResponse,
+}) => {
+  llm.mockResolvedValue(mockResponse());
+  const result = await popReferenceItem(sentence, description, options);
+  return result.length;
+};
 
-    expect(result).toEqual(mockResponse.references);
-    expect(llm).toHaveBeenCalledWith(
-      expect.stringContaining('Find pop culture references'),
-      expect.any(Object)
-    );
-  });
+runTable({
+  describe: 'popReferenceItem: result count',
+  examples: itemCountExamples,
+  process: itemCountProcessor,
+});
 
-  it('should include specific sources when provided', async () => {
-    const mockResponse = {
-      references: [
-        {
-          reference: "Michael Scott's 'That's what she said'",
-          source: 'The Office',
-          score: 0.75,
-          match: {
-            text: 'awkward silence',
-            start: 20,
-            end: 35,
-          },
-        },
-      ],
-    };
+// ─── popReferenceItem prompt construction ─────────────────────────────────
+//
+// Prompt-shape assertions don't fit the want/got compare cleanly — they
+// inspect call args, not return values. Kept imperative.
 
-    llm.mockResolvedValue(mockResponse);
-
-    const result = await popReferenceItem(
-      'There was an awkward silence after the joke',
-      'uncomfortable social moment',
-      {
-        include: ['The Office', 'Parks and Recreation'],
-      }
-    );
-
-    expect(result).toEqual(mockResponse.references);
+describe('popReferenceItem: prompt construction', () => {
+  it('mentions sources when include is provided', async () => {
+    llm.mockResolvedValue(popReferenceVariants.wellFormed());
+    await popReferenceItem('any sentence', 'desc', { include: ['The Office'] });
     expect(llm).toHaveBeenCalledWith(expect.stringContaining('<sources>'), expect.any(Object));
   });
 
-  it('should handle weighted sources', async () => {
-    const mockResponse = {
-      references: [
-        {
-          reference: "when the guy in the 'this is fine' meme just sits in the fire",
-          source: 'Meme: This Is Fine',
-          score: 0.83,
-          match: {
-            text: 'kept smiling',
-            start: 5,
-            end: 17,
-          },
-        },
+  it('formats weighted sources with focus percentage', async () => {
+    llm.mockResolvedValue(popReferenceVariants.wellFormed());
+    await popReferenceItem('any sentence', 'desc', {
+      include: [
+        { reference: 'Internet Memes', percent: 80 },
+        { reference: 'The Office', percent: 20 },
       ],
-    };
-
-    llm.mockResolvedValue(mockResponse);
-
-    const result = await popReferenceItem(
-      'They kept smiling through the chaos',
-      'maintaining composure during disaster',
-      {
-        include: [
-          { reference: 'Internet Memes', percent: 80 },
-          { reference: 'The Office', percent: 20 },
-        ],
-      }
-    );
-
-    expect(result).toEqual(mockResponse.references);
+    });
     expect(llm).toHaveBeenCalledWith(
       expect.stringContaining('Internet Memes (focus 80%)'),
       expect.any(Object)
     );
   });
 
-  it('should respect referencesPerSource option', async () => {
-    const mockResponse = {
-      references: [
-        {
-          reference: "Harry's scar burning",
-          source: 'Harry Potter',
-          score: 0.8,
-          match: { text: 'warning sign', start: 10, end: 22 },
-        },
-        {
-          reference: 'Hermione raising her hand',
-          source: 'Harry Potter',
-          score: 0.7,
-          match: { text: 'warning sign', start: 10, end: 22 },
-        },
-        {
-          reference: "Ron's face when he sees spiders",
-          source: 'Harry Potter',
-          score: 0.65,
-          match: { text: 'warning sign', start: 10, end: 22 },
-        },
-      ],
-    };
-
-    llm.mockResolvedValue(mockResponse);
-
-    const result = await popReferenceItem(
-      'It was a warning sign of things to come',
-      'ominous foreshadowing',
-      {
-        include: ['Harry Potter'],
-        referencesPerSource: 3,
-      }
-    );
-
-    expect(result.length).toBe(3);
+  it('respects referencesPerSource', async () => {
+    llm.mockResolvedValue(popReferenceVariants.wellFormed());
+    await popReferenceItem('any sentence', 'desc', { referencesPerSource: 3 });
     expect(llm).toHaveBeenCalledWith(
       expect.stringContaining('Find 3 references per source'),
       expect.any(Object)
     );
   });
-
-  it('should handle parsing errors gracefully', async () => {
-    llm.mockResolvedValue('invalid json');
-
-    await expect(popReferenceItem('Test', 'Description')).rejects.toThrow();
-  });
-
-  it('should handle empty reference arrays', async () => {
-    llm.mockResolvedValue({ references: [] });
-
-    const result = await popReferenceItem(
-      'A very unique situation',
-      'no clear pop culture parallels'
-    );
-
-    expect(result).toEqual([]);
-  });
 });
 
-describe('mapPopReferenceParallel', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+// ─── mapPopReferenceParallel ──────────────────────────────────────────────
 
+describe('mapPopReferenceParallel', () => {
   it('runs popReferenceItem per sentence with one shared description', async () => {
     llm
-      .mockResolvedValueOnce({
-        references: [
-          { reference: 'A', source: 's', score: 1, match: { text: 't', start: 0, end: 1 } },
-        ],
-      })
-      .mockResolvedValueOnce({ references: [] });
+      .mockResolvedValueOnce(popReferenceWithCount(1))
+      .mockResolvedValueOnce(popReferenceVariants.empty());
     const result = await mapPopReferenceParallel(['s1', 's2'], 'shared description');
     expect(result).toHaveLength(2);
     expect(result[0]).toHaveLength(1);
@@ -236,7 +135,9 @@ describe('mapPopReferenceParallel', () => {
   });
 
   it('reports partial outcome when one sentence fails', async () => {
-    llm.mockResolvedValueOnce({ references: [] }).mockRejectedValueOnce(new Error('boom'));
+    llm
+      .mockResolvedValueOnce(popReferenceVariants.empty())
+      .mockRejectedValueOnce(new Error('boom'));
     const events = [];
     const result = await mapPopReferenceParallel(['ok', 'bad'], 'desc', {
       maxAttempts: 1,
@@ -255,23 +156,14 @@ describe('mapPopReferenceParallel', () => {
   });
 });
 
-describe('mapPopReference (batched)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+// ─── mapPopReference (batched) ────────────────────────────────────────────
 
+describe('mapPopReference (batched)', () => {
   it('routes through map() with the pop-reference batch responseFormat', async () => {
-    vi.mocked(map).mockResolvedValueOnce([
-      {
-        references: [
-          { reference: 'A', source: 's', score: 1, match: { text: 't', start: 0, end: 1 } },
-        ],
-      },
-      { references: [] },
-    ]);
+    vi.mocked(map).mockResolvedValueOnce([popReferenceWithCount(1), popReferenceVariants.empty()]);
     const result = await mapPopReference(['s1', 's2'], 'description');
     expect(result).toHaveLength(2);
-    expect(result[0][0].reference).toBe('A');
+    expect(result[0][0].reference).toBeTruthy();
     expect(result[1]).toEqual([]);
     const mapConfig = vi.mocked(map).mock.calls[0][2];
     expect(mapConfig.responseFormat?.json_schema?.name).toBe('pop_reference_batch');

--- a/src/lib/examples-runner/index.js
+++ b/src/lib/examples-runner/index.js
@@ -1,0 +1,162 @@
+/**
+ * Table-driven examples runner.
+ *
+ * Lets specs declare an `examples` array of `{ name, inputs, want, vary? }`
+ * objects and a single `process(inputs) → result` function. The runner
+ * dispatches every example through the processor and asserts the result
+ * against `want`.
+ *
+ * `vary` is optional. When set, `expandExamples` cross-products its axes
+ * so one row becomes N rows — one per combination — with the varied
+ * params merged into `inputs` and the row name suffixed for uniqueness.
+ *
+ * `want` may be:
+ *  - a literal value: deep-equal compare via `expect(...).toEqual(...)`
+ *  - a function `(varied) => expected`: called per row, then deep-equal
+ *  - `{ throws: true }`: assert the processor throws (sync or async)
+ *  - `{ throws: <string|RegExp> }`: assert the throw message matches
+ *  - `{ eq: <value> }`: assert via `toBe` (reference/identity equality)
+ *
+ * `inputs` may be a literal value or a function `(varied) => inputs`.
+ * The function form is what makes the future migration painless — when a
+ * cross-product expands to many rows, every row gets its own freshly-built
+ * inputs object.
+ */
+
+import {
+  describe as vDescribe,
+  it as vIt,
+  expect as vExpect,
+  beforeEach as vBeforeEach,
+} from 'vitest';
+
+function cartesian(arrays) {
+  return arrays.reduce((acc, arr) => acc.flatMap((combo) => arr.map((v) => [...combo, v])), [[]]);
+}
+
+function formatVal(v) {
+  if (v === null) return 'null';
+  if (v === undefined) return 'undefined';
+  if (typeof v === 'string') return JSON.stringify(v);
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  const json = JSON.stringify(v);
+  return json && json.length <= 30 ? json : `${typeof v}<${json?.slice(0, 28)}…>`;
+}
+
+function suffixFromVaried(varied) {
+  return Object.entries(varied)
+    .map(([k, v]) => `${k}=${formatVal(v)}`)
+    .join(', ');
+}
+
+function resolve(field, varied) {
+  return typeof field === 'function' ? field(varied) : field;
+}
+
+/**
+ * Expand an array of examples by cross-producting each example's `vary` axes.
+ * Examples with no `vary` (or empty axes) pass through unchanged. Returns a
+ * new array; never mutates input.
+ *
+ * @param {Array<{ name: string, inputs?: any, want?: any, vary?: object }>} examples
+ * @returns {Array<{ name: string, inputs: any, want: any, varied: object }>}
+ */
+export function expandExamples(examples) {
+  const out = [];
+  for (const ex of examples) {
+    const axes = ex.vary ? Object.entries(ex.vary).filter(([, vs]) => vs && vs.length) : [];
+    if (axes.length === 0) {
+      out.push({
+        name: ex.name,
+        inputs: resolve(ex.inputs, {}),
+        want: resolve(ex.want, {}),
+        varied: {},
+      });
+      continue;
+    }
+    const combos = cartesian(axes.map(([, vs]) => vs));
+    for (const combo of combos) {
+      const varied = Object.fromEntries(axes.map(([name], i) => [name, combo[i]]));
+      out.push({
+        name: `${ex.name} (${suffixFromVaried(varied)})`,
+        inputs: resolve(ex.inputs, varied),
+        want: resolve(ex.want, varied),
+        varied,
+      });
+    }
+  }
+  return out;
+}
+
+function isThrowSpec(want) {
+  return want && typeof want === 'object' && Object.prototype.hasOwnProperty.call(want, 'throws');
+}
+
+function isEqSpec(want) {
+  return want && typeof want === 'object' && Object.prototype.hasOwnProperty.call(want, 'eq');
+}
+
+async function assertThrows(thrower, throws) {
+  let caught;
+  try {
+    await Promise.resolve(thrower());
+  } catch (err) {
+    caught = err;
+  }
+  if (!caught) {
+    throw new Error('expected processor to throw, but it returned successfully');
+  }
+  if (throws === true) return;
+  const msg = caught.message ?? String(caught);
+  if (typeof throws === 'string') {
+    vExpect(msg).toContain(throws);
+  } else if (throws instanceof RegExp) {
+    vExpect(msg).toMatch(throws);
+  } else {
+    // unrecognized throws spec — accept any throw, surface what we got
+    vExpect(caught).toBeInstanceOf(Error);
+  }
+}
+
+/**
+ * Run a table of examples through a processor.
+ *
+ * @param {object} config
+ * @param {string} [config.describe]   Optional `describe` name. Omit to inline rows.
+ * @param {Array} config.examples       Array of example rows (will be expanded).
+ * @param {Function} config.process     `(inputs) => result | Promise<result>`.
+ * @param {Function} [config.beforeEach] Optional before-each hook.
+ *
+ * Tests are emitted via vitest's `it` and `expect`; this is not a generic
+ * runner. A spec file using `runTable` must be discovered by vitest in the
+ * usual way.
+ */
+export function runTable({ describe: describeName, examples, process, beforeEach }) {
+  const expanded = expandExamples(examples);
+
+  const body = () => {
+    if (beforeEach) vBeforeEach(beforeEach);
+    for (const ex of expanded) {
+      vIt(ex.name, async () => {
+        if (isThrowSpec(ex.want)) {
+          await assertThrows(() => process(ex.inputs), ex.want.throws);
+          return;
+        }
+        const result = await process(ex.inputs);
+        if (isEqSpec(ex.want)) {
+          vExpect(result).toBe(ex.want.eq);
+        } else {
+          vExpect(result).toEqual(ex.want);
+        }
+      });
+    }
+  };
+
+  if (describeName) {
+    vDescribe(describeName, body);
+  } else {
+    body();
+  }
+}
+
+export default runTable;

--- a/src/lib/examples-runner/index.js
+++ b/src/lib/examples-runner/index.js
@@ -16,6 +16,12 @@
  *  - `{ throws: true }`: assert the processor throws (sync or async)
  *  - `{ throws: <string|RegExp> }`: assert the throw message matches
  *  - `{ eq: <value> }`: assert via `toBe` (reference/identity equality)
+ *  - `{ contains: <value> }`: assert via `toContain` (substring, array element, etc.)
+ *  - `{ matches: <string|RegExp> }`: assert via `toMatch`
+ *  - `{ partial: <object> }`: assert via `toMatchObject` (subset match)
+ *
+ * Compound matchers may be combined: `{ contains: 'X', matches: /\d+/ }` runs
+ * both checks. `throws` is exclusive — when set, the other matchers are ignored.
  *
  * `inputs` may be a literal value or a function `(varied) => inputs`.
  * The function form is what makes the future migration painless — when a
@@ -88,12 +94,15 @@ export function expandExamples(examples) {
   return out;
 }
 
+const MATCHER_KEYS = ['eq', 'contains', 'matches', 'partial'];
+
 function isThrowSpec(want) {
   return want && typeof want === 'object' && Object.prototype.hasOwnProperty.call(want, 'throws');
 }
 
-function isEqSpec(want) {
-  return want && typeof want === 'object' && Object.prototype.hasOwnProperty.call(want, 'eq');
+function matcherKeys(want) {
+  if (!want || typeof want !== 'object' || Array.isArray(want)) return [];
+  return MATCHER_KEYS.filter((k) => Object.prototype.hasOwnProperty.call(want, k));
 }
 
 async function assertThrows(thrower, throws) {
@@ -143,10 +152,16 @@ export function runTable({ describe: describeName, examples, process, beforeEach
           return;
         }
         const result = await process(ex.inputs);
-        if (isEqSpec(ex.want)) {
-          vExpect(result).toBe(ex.want.eq);
-        } else {
+        const keys = matcherKeys(ex.want);
+        if (keys.length === 0) {
           vExpect(result).toEqual(ex.want);
+          return;
+        }
+        for (const key of keys) {
+          if (key === 'eq') vExpect(result).toBe(ex.want.eq);
+          else if (key === 'contains') vExpect(result).toContain(ex.want.contains);
+          else if (key === 'matches') vExpect(result).toMatch(ex.want.matches);
+          else if (key === 'partial') vExpect(result).toMatchObject(ex.want.partial);
         }
       });
     }

--- a/src/lib/examples-runner/index.spec.js
+++ b/src/lib/examples-runner/index.spec.js
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import { expandExamples, runTable } from './index.js';
+
+// ─── expandExamples ────────────────────────────────────────────────────────
+//
+// Pure transform — verify cross-product expansion, function-form inputs/want,
+// and pass-through for examples without `vary`.
+
+const expandCases = [
+  {
+    name: 'pass through when vary is absent',
+    inputs: {
+      examples: [{ name: 'plain', inputs: { a: 1 }, want: { result: 2 } }],
+    },
+    want: [{ name: 'plain', inputs: { a: 1 }, want: { result: 2 }, varied: {} }],
+  },
+  {
+    name: 'pass through when vary is empty object',
+    inputs: {
+      examples: [{ name: 'plain', inputs: { a: 1 }, want: 2, vary: {} }],
+    },
+    want: [{ name: 'plain', inputs: { a: 1 }, want: 2, varied: {} }],
+  },
+  {
+    name: 'expand single-axis vary into N rows',
+    inputs: {
+      examples: [
+        {
+          name: 'increment',
+          inputs: ({ x }) => ({ x }),
+          want: ({ x }) => x + 1,
+          vary: { x: [1, 2, 3] },
+        },
+      ],
+    },
+    want: [
+      { name: 'increment (x=1)', inputs: { x: 1 }, want: 2, varied: { x: 1 } },
+      { name: 'increment (x=2)', inputs: { x: 2 }, want: 3, varied: { x: 2 } },
+      { name: 'increment (x=3)', inputs: { x: 3 }, want: 4, varied: { x: 3 } },
+    ],
+  },
+  {
+    name: 'expand two-axis vary into the cross product',
+    inputs: {
+      examples: [
+        {
+          name: 'add',
+          inputs: ({ a, b }) => ({ a, b }),
+          want: ({ a, b }) => a + b,
+          vary: { a: [1, 2], b: [10, 20] },
+        },
+      ],
+    },
+    want: [
+      { name: 'add (a=1, b=10)', inputs: { a: 1, b: 10 }, want: 11, varied: { a: 1, b: 10 } },
+      { name: 'add (a=1, b=20)', inputs: { a: 1, b: 20 }, want: 21, varied: { a: 1, b: 20 } },
+      { name: 'add (a=2, b=10)', inputs: { a: 2, b: 10 }, want: 12, varied: { a: 2, b: 10 } },
+      { name: 'add (a=2, b=20)', inputs: { a: 2, b: 20 }, want: 22, varied: { a: 2, b: 20 } },
+    ],
+  },
+  {
+    name: 'static want reused across all combinations',
+    inputs: {
+      examples: [
+        {
+          name: 'identity is stable',
+          inputs: ({ flag }) => ({ flag }),
+          want: 'always',
+          vary: { flag: [true, false] },
+        },
+      ],
+    },
+    want: [
+      {
+        name: 'identity is stable (flag=true)',
+        inputs: { flag: true },
+        want: 'always',
+        varied: { flag: true },
+      },
+      {
+        name: 'identity is stable (flag=false)',
+        inputs: { flag: false },
+        want: 'always',
+        varied: { flag: false },
+      },
+    ],
+  },
+  {
+    name: 'static inputs reused across all combinations',
+    inputs: {
+      examples: [
+        {
+          name: 'counts',
+          inputs: { items: [1, 2, 3] },
+          want: ({ batchSize }) => ({ items: [1, 2, 3], batchSize }),
+          vary: { batchSize: [1, 5] },
+        },
+      ],
+    },
+    want: [
+      {
+        name: 'counts (batchSize=1)',
+        inputs: { items: [1, 2, 3] },
+        want: { items: [1, 2, 3], batchSize: 1 },
+        varied: { batchSize: 1 },
+      },
+      {
+        name: 'counts (batchSize=5)',
+        inputs: { items: [1, 2, 3] },
+        want: { items: [1, 2, 3], batchSize: 5 },
+        varied: { batchSize: 5 },
+      },
+    ],
+  },
+  {
+    name: 'empty axis values are skipped (cross-product would zero out otherwise)',
+    inputs: {
+      examples: [
+        {
+          name: 'partial',
+          inputs: ({ a }) => ({ a }),
+          want: ({ a }) => a,
+          vary: { a: [1, 2], unused: [] },
+        },
+      ],
+    },
+    want: [
+      { name: 'partial (a=1)', inputs: { a: 1 }, want: 1, varied: { a: 1 } },
+      { name: 'partial (a=2)', inputs: { a: 2 }, want: 2, varied: { a: 2 } },
+    ],
+  },
+];
+
+describe('expandExamples', () => {
+  for (const c of expandCases) {
+    it(c.name, () => {
+      expect(expandExamples(c.inputs.examples)).toEqual(c.want);
+    });
+  }
+
+  it('does not mutate the input examples array', () => {
+    const examples = [{ name: 'p', inputs: { a: 1 }, want: 2 }];
+    const before = JSON.stringify(examples);
+    expandExamples(examples);
+    expect(JSON.stringify(examples)).toBe(before);
+  });
+});
+
+// ─── runTable: identity, sync, deep-equal ──────────────────────────────────
+//
+// Eats its own dog food: the harness drives a tiny processor with a literal
+// table. If these pass, the runner can drive vitest correctly. We mix
+// throw-spec, eq-spec, deep-equal, and a vary-expanded row.
+
+const sumProcessor = ({ a, b }) => a + b;
+const identityProcessor = (x) => x;
+const throwingProcessor = ({ msg }) => {
+  throw new Error(msg);
+};
+
+runTable({
+  describe: 'runTable: deep-equal default (sync)',
+  examples: [
+    { name: '1 + 2 = 3', inputs: { a: 1, b: 2 }, want: 3 },
+    { name: '0 + 0 = 0', inputs: { a: 0, b: 0 }, want: 0 },
+    { name: 'negatives', inputs: { a: -5, b: 3 }, want: -2 },
+  ],
+  process: sumProcessor,
+});
+
+// `{ eq }` exercises the toBe path. We use a frozen reference so toEqual would
+// also pass — the spec is verifying the path runs, not distinguishing equality
+// modes. Use cases where toBe vs toEqual diverge live in chain-level specs.
+const SHARED_REF = Object.freeze({ a: 1 });
+runTable({
+  describe: 'runTable: identity equality via { eq } spec',
+  examples: [{ name: 'same reference passes', inputs: SHARED_REF, want: { eq: SHARED_REF } }],
+  process: identityProcessor,
+});
+
+runTable({
+  describe: 'runTable: throws spec accepts true / string / RegExp',
+  examples: [
+    { name: 'throws=true accepts any error', inputs: { msg: 'boom' }, want: { throws: true } },
+    {
+      name: 'throws=string substring matches',
+      inputs: { msg: 'kaboom now' },
+      want: { throws: 'kaboom' },
+    },
+    {
+      name: 'throws=regexp matches',
+      inputs: { msg: 'rate limited (429)' },
+      want: { throws: /\(\d+\)/ },
+    },
+  ],
+  process: throwingProcessor,
+});
+
+runTable({
+  describe: 'runTable: vary expands rows',
+  examples: [
+    {
+      name: 'sum',
+      inputs: ({ a, b }) => ({ a, b }),
+      want: ({ a, b }) => a + b,
+      vary: { a: [1, 2], b: [10, 100] },
+    },
+  ],
+  process: sumProcessor,
+});
+
+// async processor coverage
+runTable({
+  describe: 'runTable: async processor',
+  examples: [
+    {
+      name: 'awaits the result',
+      inputs: { delay: 1, value: 42 },
+      want: 42,
+    },
+  ],
+  process: async ({ delay, value }) => {
+    await new Promise((r) => setTimeout(r, delay));
+    return value;
+  },
+});

--- a/src/lib/examples-runner/index.spec.js
+++ b/src/lib/examples-runner/index.spec.js
@@ -224,3 +224,49 @@ runTable({
     return value;
   },
 });
+
+// `{ contains }` — substring (string) and element (array)
+runTable({
+  describe: 'runTable: contains spec',
+  examples: [
+    { name: 'string contains substring', inputs: 'hello world', want: { contains: 'world' } },
+    { name: 'array contains element', inputs: [1, 2, 3], want: { contains: 2 } },
+  ],
+  process: identityProcessor,
+});
+
+// `{ matches }` — string + RegExp
+runTable({
+  describe: 'runTable: matches spec',
+  examples: [
+    { name: 'matches RegExp', inputs: 'rate limited (429)', want: { matches: /\(\d+\)/ } },
+    { name: 'matches string substring', inputs: 'hello world', want: { matches: 'world' } },
+  ],
+  process: identityProcessor,
+});
+
+// `{ partial }` — toMatchObject
+runTable({
+  describe: 'runTable: partial spec',
+  examples: [
+    {
+      name: 'asserts only specific fields of a complex object',
+      inputs: { a: 1, b: 2, c: 3, nested: { x: 10, y: 20 } },
+      want: { partial: { a: 1, nested: { x: 10 } } },
+    },
+  ],
+  process: identityProcessor,
+});
+
+// Compound matchers combine
+runTable({
+  describe: 'runTable: combined matchers',
+  examples: [
+    {
+      name: 'contains + matches both apply',
+      inputs: 'rate limited (429) on attempt 3',
+      want: { contains: 'rate limited', matches: /\(\d+\)/ },
+    },
+  ],
+  process: identityProcessor,
+});

--- a/src/lib/pave/index.spec.js
+++ b/src/lib/pave/index.spec.js
@@ -1,76 +1,72 @@
-import { describe, expect, it } from 'vitest';
-
 import pave from './index.js';
+import { runTable } from '../examples-runner/index.js';
+
+// Reference migration to the table-driven runner. The previous pattern (an
+// `examples = [{ name, inputs, want: { result | throws } }]` array driven by
+// a `forEach` + inline `it`) was already 95% in target shape; this version
+// drops the imperative scaffolding and lets `runTable` dispatch every row.
+//
+// `want` is the literal expected return value (deep-equal). For error cases
+// we use `{ throws: true }` — the runner accepts that shape directly.
 
 const examples = [
   {
-    name: 'Set a nested object value',
+    name: 'set a nested object value',
     inputs: { obj: {}, path: 'a.b.c', value: 42 },
-    want: { result: { a: { b: { c: 42 } } } },
+    want: { a: { b: { c: 42 } } },
   },
   {
-    name: 'Set a nested array value',
+    name: 'set a nested array value',
     inputs: { obj: [], path: '0.1.2', value: 42 },
-    want: { result: [[undefined, [undefined, undefined, 42]]] },
+    want: [[undefined, [undefined, undefined, 42]]],
   },
   {
-    name: 'Set a mixed object and array value',
+    name: 'set a mixed object and array value',
     inputs: { obj: {}, path: 'a.0.b', value: 42 },
-    want: { result: { a: [{ b: 42 }] } },
+    want: { a: [{ b: 42 }] },
   },
   {
-    name: 'Set a value on an existing object',
+    name: 'set a value on an existing object',
     inputs: { obj: { x: { y: 1 } }, path: 'x.z', value: 2 },
-    want: { result: { x: { y: 1, z: 2 } } },
+    want: { x: { y: 1, z: 2 } },
   },
   {
-    name: 'Set a value on an existing array',
+    name: 'set a value on an existing array',
     inputs: { obj: [0, [1]], path: '1.2', value: 3 },
-    want: { result: [0, [1, undefined, 3]] },
+    want: [0, [1, undefined, 3]],
   },
   {
-    name: 'Override an existing value in an object',
+    name: 'override an existing value in an object',
     inputs: { obj: { a: { b: 1 } }, path: 'a.b', value: 99 },
-    want: { result: { a: { b: 99 } } },
+    want: { a: { b: 99 } },
   },
   {
-    name: 'Override an existing value in an array',
+    name: 'override an existing value in an array',
     inputs: { obj: [0, [1, 2]], path: '1.1', value: 99 },
-    want: { result: [0, [1, 99]] },
+    want: [0, [1, 99]],
   },
   {
-    name: 'Set a value with an empty path (throws)',
+    name: 'throws on an empty path',
     inputs: { obj: { x: 1 }, path: '', value: 42 },
     want: { throws: true },
   },
   {
-    name: 'Set a value with an invalid path (throws)',
+    name: 'throws on an invalid path',
     inputs: { obj: { x: 1 }, path: '.', value: 42 },
     want: { throws: true },
   },
   {
-    name: 'Set a value with a single element path on an object',
+    name: 'set a value with a single-element path on an object',
     inputs: { obj: {}, path: 'a', value: 42 },
-    want: { result: { a: 42 } },
+    want: { a: 42 },
   },
   {
-    name: 'Handle numeric-like string keys',
+    name: 'handle numeric-like string keys',
     inputs: { obj: {}, path: 'a.1b.c', value: 42 },
-    want: { result: { a: { '1b': { c: 42 } } } },
+    want: { a: { '1b': { c: 42 } } },
   },
 ];
 
-describe('pave', () => {
-  examples.forEach((example) => {
-    it(example.name, () => {
-      const { obj } = example.inputs;
+const process = ({ obj, path, value }) => pave(obj, path, value);
 
-      if (example.want.throws) {
-        expect(() => pave(obj, example.inputs.path, example.inputs.value)).toThrow();
-      } else {
-        const result = pave(obj, example.inputs.path, example.inputs.value);
-        expect(result).toEqual(example.want.result);
-      }
-    });
-  });
-});
+runTable({ describe: 'pave', examples, process });

--- a/src/lib/test-utils/factories/index.js
+++ b/src/lib/test-utils/factories/index.js
@@ -1,0 +1,23 @@
+/**
+ * Fishery factory families for the verblets test suite.
+ *
+ * Each chain (or chain cluster) has its own factory module. The shared
+ * `variants` helper produces the standard failure-variant set
+ * (wellFormed, empty, isNull, malformedShape, rejected, undersized, oversized)
+ * from a fishery base factory, so spec readers see consistent variant
+ * vocabulary even when the underlying response shapes differ.
+ *
+ * Add new families by creating a new file in this directory and re-exporting
+ * here. Don't force a common base shape — align variant *names*, not
+ * payload structures.
+ */
+
+export {
+  popReferenceFactory,
+  popReferenceMatchFactory,
+  popReferenceResponseFactory,
+  popReferenceVariants,
+  popReferenceWithCount,
+} from './pop-reference.js';
+
+export { makeResponseVariants, rejectedWith } from './variants.js';

--- a/src/lib/test-utils/factories/index.spec.js
+++ b/src/lib/test-utils/factories/index.spec.js
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import {
+  popReferenceFactory,
+  popReferenceMatchFactory,
+  popReferenceResponseFactory,
+  popReferenceVariants,
+  popReferenceWithCount,
+  makeResponseVariants,
+} from './index.js';
+import { runTable } from '../../examples-runner/index.js';
+
+// ─── pop-reference factories ───────────────────────────────────────────────
+//
+// Verify each fishery factory produces the documented shape, sequence
+// counters advance, and overrides take effect.
+
+describe('popReferenceMatchFactory', () => {
+  it('builds a match with text, start, end', () => {
+    const m = popReferenceMatchFactory.build();
+    expect(m).toEqual(
+      expect.objectContaining({
+        text: expect.any(String),
+        start: expect.any(Number),
+        end: expect.any(Number),
+      })
+    );
+  });
+
+  it('sequence advances on successive builds', () => {
+    const a = popReferenceMatchFactory.build();
+    const b = popReferenceMatchFactory.build();
+    expect(b.start).toBeGreaterThan(a.start);
+  });
+
+  it('overrides take effect', () => {
+    const m = popReferenceMatchFactory.build({ text: 'manual', start: 0, end: 6 });
+    expect(m).toEqual({ text: 'manual', start: 0, end: 6 });
+  });
+});
+
+describe('popReferenceFactory', () => {
+  it('builds a reference with all required fields', () => {
+    const r = popReferenceFactory.build();
+    expect(r).toEqual(
+      expect.objectContaining({
+        reference: expect.any(String),
+        source: expect.any(String),
+        score: expect.any(Number),
+        match: expect.objectContaining({
+          text: expect.any(String),
+          start: expect.any(Number),
+          end: expect.any(Number),
+        }),
+      })
+    );
+    expect(r.score).toBeGreaterThanOrEqual(0);
+    expect(r.score).toBeLessThanOrEqual(1);
+  });
+
+  it('buildList(n) returns n distinct references', () => {
+    const list = popReferenceFactory.buildList(4);
+    expect(list).toHaveLength(4);
+    const refs = new Set(list.map((r) => r.reference));
+    expect(refs.size).toBe(4);
+  });
+});
+
+describe('popReferenceResponseFactory', () => {
+  it('builds a response with references[]', () => {
+    const r = popReferenceResponseFactory.build();
+    expect(Array.isArray(r.references)).toBe(true);
+    expect(r.references.length).toBeGreaterThan(0);
+  });
+
+  it('overriding references replaces the array', () => {
+    const r = popReferenceResponseFactory.build({ references: [] });
+    expect(r.references).toEqual([]);
+  });
+});
+
+describe('popReferenceWithCount', () => {
+  it.each([0, 1, 3, 7])('produces a response with %i references', (n) => {
+    expect(popReferenceWithCount(n).references).toHaveLength(n);
+  });
+});
+
+// ─── variants vocabulary (LlmMockResponse contract) ────────────────────────
+//
+// The variants share names across chains, even when the payload shapes differ.
+// These tests pin the contract for pop-reference; other chains will have
+// equivalent specs using the same expected variant keys.
+
+const expectedVariantKeys = [
+  'wellFormed',
+  'empty',
+  'isNull',
+  'undefinedValue',
+  'malformedShape',
+  'rejected',
+  'undersized',
+  'oversized',
+];
+
+describe('popReferenceVariants', () => {
+  it.each(expectedVariantKeys)('exposes %s', (key) => {
+    expect(typeof popReferenceVariants[key]).toBe('function');
+  });
+
+  it('wellFormed returns the documented response shape', () => {
+    const r = popReferenceVariants.wellFormed();
+    expect(Array.isArray(r.references)).toBe(true);
+  });
+
+  it('empty returns { references: [] }', () => {
+    expect(popReferenceVariants.empty()).toEqual({ references: [] });
+  });
+
+  it('isNull returns null', () => {
+    expect(popReferenceVariants.isNull()).toBeNull();
+  });
+
+  it('undefinedValue returns undefined', () => {
+    expect(popReferenceVariants.undefinedValue()).toBeUndefined();
+  });
+
+  it('malformedShape returns a deliberately wrong shape', () => {
+    const r = popReferenceVariants.malformedShape();
+    expect(r).not.toHaveProperty('references');
+  });
+
+  it('rejected throws the supplied error', () => {
+    const err = new Error('rate limit');
+    expect(() => popReferenceVariants.rejected(err)).toThrow('rate limit');
+  });
+
+  it('undersized returns an empty references array', () => {
+    expect(popReferenceVariants.undersized().references).toEqual([]);
+  });
+
+  it('oversized returns more than the well-formed default', () => {
+    const wellFormedSize = popReferenceVariants.wellFormed().references.length;
+    expect(popReferenceVariants.oversized().references.length).toBeGreaterThan(wellFormedSize);
+  });
+});
+
+// ─── makeResponseVariants helper itself ────────────────────────────────────
+//
+// Driven through runTable: confirms the helper rejects bad inputs and
+// produces every expected variant key when the inputs are good.
+
+import { Factory } from 'fishery';
+
+const exampleBase = Factory.define(() => ({ items: [{ id: 1 }] }));
+
+const variantsBuilderCases = [
+  {
+    name: 'throws when base is not a fishery Factory',
+    inputs: { base: null },
+    want: { throws: 'fishery Factory' },
+  },
+  {
+    name: 'returns base variants when arrayKey is set with makeArrayItem',
+    inputs: { base: exampleBase, arrayKey: 'items', makeArrayItem: () => ({ id: 2 }) },
+    // Object.keys().sort() — alphabetical
+    want: [
+      'empty',
+      'isNull',
+      'malformedShape',
+      'oversized',
+      'rejected',
+      'undefinedValue',
+      'undersized',
+      'wellFormed',
+    ],
+  },
+  {
+    name: 'omits size variants when arrayKey is null',
+    inputs: { base: exampleBase, arrayKey: null },
+    want: ['empty', 'isNull', 'malformedShape', 'rejected', 'undefinedValue', 'wellFormed'],
+  },
+];
+
+runTable({
+  describe: 'makeResponseVariants',
+  examples: variantsBuilderCases,
+  process: (inputs) => {
+    const result = makeResponseVariants(inputs);
+    return Object.keys(result).sort();
+  },
+});
+
+// The first case is a throw spec; the second/third assert sorted-key arrays —
+// align the want arrays with sort order.

--- a/src/lib/test-utils/factories/pop-reference.js
+++ b/src/lib/test-utils/factories/pop-reference.js
@@ -1,0 +1,45 @@
+import { Factory } from 'fishery';
+import { makeResponseVariants } from './variants.js';
+
+/**
+ * Factories for pop-reference's LLM responses.
+ *
+ * Shape (per `src/chains/pop-reference/pop-reference-result.json`):
+ *   { references: [ { reference, source, score, match: { text, start, end }, context? } ] }
+ *
+ * Variant naming follows the project-wide vocabulary:
+ *   wellFormed, empty, isNull, undefinedValue, malformedShape, rejected,
+ *   undersized, oversized.
+ *
+ * Each variant is a thunk so callers can pass it directly to `mockResolvedValue`,
+ * `mockImplementation`, etc., without having to remember whether to call it.
+ */
+
+const SOURCES = ['The Matrix', 'The Office', 'Lord of the Rings', 'Star Wars', 'Internet Memes'];
+
+export const popReferenceMatchFactory = Factory.define(({ sequence }) => ({
+  text: `fragment-${sequence}`,
+  start: sequence,
+  end: sequence + 8,
+}));
+
+export const popReferenceFactory = Factory.define(({ sequence }) => ({
+  reference: `cultural moment #${sequence}`,
+  source: SOURCES[sequence % SOURCES.length],
+  score: 0.5 + (sequence % 5) * 0.1,
+  match: popReferenceMatchFactory.build(),
+}));
+
+export const popReferenceResponseFactory = Factory.define(() => ({
+  references: popReferenceFactory.buildList(2),
+}));
+
+export const popReferenceVariants = makeResponseVariants({
+  base: popReferenceResponseFactory,
+  arrayKey: 'references',
+  makeArrayItem: () => popReferenceFactory.build(),
+});
+
+/** Convenience: build a response with N references at construction time. */
+export const popReferenceWithCount = (n) =>
+  popReferenceResponseFactory.build({ references: popReferenceFactory.buildList(n) });

--- a/src/lib/test-utils/factories/variants.js
+++ b/src/lib/test-utils/factories/variants.js
@@ -1,0 +1,65 @@
+/**
+ * Shared variant vocabulary for LLM mock responses.
+ *
+ * Each chain has its own well-formed response shape (pop-reference returns
+ * `{ references: [...] }`, score returns `{ value: number|string }`, etc.) —
+ * we don't force them into a common base. What we *do* align is the *naming*
+ * of the failure variants, so spec readers see consistent variant labels
+ * across chains.
+ *
+ * `makeResponseVariants` takes a fishery base factory and an `arrayKey`
+ * (the property whose value is the result array, if any) and returns the
+ * standard variant set. Chains with non-array responses (e.g. score's
+ * `{ value }`) call the helper with `arrayKey: null` and skip the
+ * size-related variants.
+ */
+
+/**
+ * @param {object} opts
+ * @param {import('fishery').Factory} opts.base                 — fishery factory for the well-formed shape
+ * @param {string|null} [opts.arrayKey='items']                  — property holding the result array, or null
+ * @param {Function} [opts.makeArrayItem]                        — factory builder for one array entry (when arrayKey is set)
+ * @param {object} [opts.malformedShape={ wrong: 'shape' }]      — what to return for the malformed variant
+ * @param {*} [opts.emptyValue]                                  — value used when we return "empty"; defaults to `[]` if arrayKey is set, `null` otherwise
+ * @returns {object} variants — `{ wellFormed, empty, isNull, undefinedValue, malformedShape, rejected, undersized, oversized }`
+ */
+export function makeResponseVariants({
+  base,
+  arrayKey = 'items',
+  makeArrayItem,
+  malformedShape = { wrong: 'shape' },
+  emptyValue,
+} = {}) {
+  if (!base || typeof base.build !== 'function') {
+    throw new Error('makeResponseVariants: base must be a fishery Factory');
+  }
+
+  const computedEmpty = emptyValue ?? (arrayKey ? { [arrayKey]: [] } : null);
+
+  const variants = {
+    wellFormed: () => base.build(),
+    empty: () => computedEmpty,
+    isNull: () => null,
+    undefinedValue: () => undefined,
+    malformedShape: () => malformedShape,
+    rejected: (error = new Error('LLM call failed')) => {
+      throw error;
+    },
+  };
+
+  if (arrayKey && typeof makeArrayItem === 'function') {
+    variants.undersized = () => base.build({ [arrayKey]: [] });
+    variants.oversized = () =>
+      base.build({ [arrayKey]: Array.from({ length: 12 }, () => makeArrayItem()) });
+  }
+
+  return variants;
+}
+
+/**
+ * Pure helper for "the LLM rejected the call" — returns a thunk that throws
+ * when invoked. Mirrors fishery's lazy-build style.
+ */
+export const rejectedWith = (error) => () => {
+  throw error instanceof Error ? error : new Error(String(error));
+};


### PR DESCRIPTION
## Summary

First implementation step toward the wider table-driven test refactor. Lands the harness, the first factory family, and two reference migrations end-to-end so subsequent module-by-module migrations have a clear pattern to follow. Pairs with #224 (inventory) — these PRs are independent; either order works.

## What lands

**`src/lib/examples-runner/`** — table-driven runner.
- `expandExamples(examples)` cross-products `vary` axes; no-vary examples pass through unchanged. `inputs` and `want` may be functions of the varied combo.
- `runTable({ describe, examples, process, beforeEach })` dispatches every expanded row through one processor. `want` accepts a literal (deep-equal), a function, `{ throws }` (with optional string/RegExp matcher) for sync/async error cases, or `{ eq }` for identity.
- 20 self-tests in the runner's own spec.

**`src/lib/test-utils/factories/`** — fishery factories.
- `variants.js` — `makeResponseVariants({ base, arrayKey, makeArrayItem })` produces the standard variant set: `wellFormed`, `empty`, `isNull`, `undefinedValue`, `malformedShape`, `rejected` (plus `undersized`/`oversized` when `arrayKey` is set). Variant **names** align across chains; payload shapes don't have to.
- `pop-reference.js` — first chain factory family with the response, reference, and match factories.
- 30 self-tests covering every variant key, driven through `runTable`.

**Reference migrations**:
- `src/lib/pave/index.spec.js` — replaces inline `examples.forEach` with `runTable`. Same 11 cases, fewer lines, `want.result` envelope removed.
- `src/chains/pop-reference/index.spec.js` — first LLM-backed chain. Result-shape assertions go through `runTable` + factory variants; prompt-construction assertions stay imperative because they inspect call args, not return values. **Mixed patterns within one file is the intended end state** — don't force every assertion into the table.

**`.claude/guidelines/unit-tests.md`** — documents the new shape and variant vocabulary so future migrations have a citation.

**`fishery`** added as `devDependencies`.

## Decisions taken (deferred questions from #224's plan)

| Question | Resolution |
|---|---|
| Add `fishery` as devDep? | Yes — small, idiomatic, `extend()` / `params()` / `sequence` map cleanly to the variant tree |
| Harness location | `src/lib/examples-runner/` (clean separation from `test-utils/` which holds contract subjects + factories) |
| Factory location | `src/lib/test-utils/factories/`, one module per chain |
| Stress merge strategy | Deferred — bulk migration PRs decide per chain |
| `fast-check` | Deferred — add only when a use case warrants it |

## Test plan

- [x] `runTable` self-tests: **20/20** pass.
- [x] Factory self-tests (incl. `makeResponseVariants` driven via `runTable`): **30/30**.
- [x] Migrated `pave` spec: **11/11**.
- [x] Migrated `pop-reference` spec: **14/14**.
- [x] Full node suite: **2,498 / 2,498**.
- [x] Browser suite: **2,104 / 2,104**.
- [x] `npm run lint` clean.

## What's next (deliberately not in this PR)

- Second factory family — likely `Score` or `Calibrate` (the next-most-used after `LlmMockResponse`).
- Module-by-module bulk migration of remaining specs, sized ~5-10 modules per PR. The order in `#224`'s `coverage.md` (lib → verblets → chains → examples → stress) is a good proxy for difficulty.