### PR TITLE
Tighten veiled-variants and clean up local-LLM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const { filter, map, bool, llm } = init({
   embed: true,            // enable local embedding model
   redis: redisClient,     // pre-configured Redis client for caching
   models: {               // extend the model catalog (additive)
-    'my-llama': { provider: 'openai', apiUrl: 'http://localhost:11434/v1', endpoint: '/chat/completions', maxContextWindow: 8192, maxOutputTokens: 4096 },
+    'my-llama': { provider: 'openwebui', apiUrl: 'http://localhost:11434/', endpoint: 'v1/chat/completions', maxContextWindow: 8192, maxOutputTokens: 4096 },
   },
   rules: [                // override negotiation rules (first match wins)
     { match: { sensitive: true, good: true }, use: 'my-llama' },

--- a/src/chains/map/README.md
+++ b/src/chains/map/README.md
@@ -26,6 +26,18 @@ const explanations = await map(
 // ]
 ```
 
+### Mapping sensitive items through a privacy-capable model
+
+When the items themselves are sensitive — patient charts, customer support transcripts, internal HR notes — pass `llm: { sensitive: true }` and the library routes the batch to whichever model your rules have designated for sensitive traffic (typically a local Ollama / OpenWebUI host). The map shape and batching behavior are unchanged:
+
+```javascript
+const summaries = await map(
+  supportTranscripts,
+  'Summarize the customer\'s issue in one sentence, omitting names and account numbers',
+  { llm: { sensitive: true } }
+);
+```
+
 ## API
 
 ### `map(list, instructions, config?)`

--- a/src/chains/questions/README.md
+++ b/src/chains/questions/README.md
@@ -20,6 +20,21 @@ const qs = await questions(
 // ]
 ```
 
+### Routing through a privacy-capable model
+
+For text that should not be sent to a cloud model — clinical notes, internal incident write-ups, anything you'd rather keep local — pass `llm: { sensitive: true }`. The library routes the call to whichever model your rules map sensitive traffic to (typically a local Ollama / OpenWebUI host):
+
+```javascript
+const qs = await questions(
+  patientNoteText,
+  {
+    exploration: 'low',
+    shouldStop: (q, all) => all.length > 10,
+    llm: { sensitive: true },
+  }
+);
+```
+
 ## API
 
 ### `questions(text, config?)`

--- a/src/chains/veiled-variants/README.md
+++ b/src/chains/veiled-variants/README.md
@@ -1,37 +1,76 @@
 # veiled-variants
 
-Reframe a prompt through multiple cognitive lenses to generate alternative phrasings. Useful when a direct query might trigger content filters or when you want diverse angles on the same question. Runs parallel LLM calls — one per strategy — and returns all variants in a flat array.
+Reframe an intent as a set of **adjacent** queries — questions whose answers, taken together, would inform the original but which never ask it directly. Useful when a direct query might trip a content filter, expose intent to an upstream observer, or when you simply want a wider net of evidence than a literal restatement would gather.
 
-The three built-in strategies:
-- **Scientific framing** — recasts the prompt as an academic research query using terminology from biology, epidemiology, or public health
-- **Causal framing** — explores causes, co-conditions, and consequences adjacent to the topic
-- **Soft cover** — reframes as general wellness or diagnostic concerns with a clinical, approachable tone
+The chain runs parallel LLM calls (one per strategy) and returns the variants flat. Each strategy aims at a different kind of "near miss":
+
+- **Scientific framing** — recasts the intent as research, diagnostic, or modeling questions in an adjacent technical field. The vocabulary shifts; the central subject is never named.
+- **Causal framing** — asks about precursors, co-conditions, and downstream effects in the neighborhood of the topic, without naming it.
+- **Soft cover** — reframes as ordinary, unremarkable practical questions from a different domain entirely. Plain voice, no clinical or domain markers.
+
+## Health-adjacent example
 
 ```javascript
 import { veiledVariants } from '@far-world-labs/verblets';
 
 const variants = await veiledVariants(
-  'What are the effects of long-term sleep deprivation?'
+  'What are the long-term effects of chronic insomnia?'
 );
 
-// Returns 15 variants (5 per strategy):
+// Returns 15 variants (5 per strategy). None mentions sleep, insomnia,
+// rest, fatigue, or any direct synonym. Sample:
 // [
-//   "What neurological biomarkers correlate with chronic sleep deficit in longitudinal cohort studies?",
-//   "How does sustained wakefulness beyond 72 hours alter hypothalamic-pituitary axis regulation?",
+//   // scientific
+//   "What metabolic markers shift in adults with sustained autonomic dysregulation?",
+//   "Which cortisol and inflammatory profiles correlate with prolonged circadian misalignment in working-age cohorts?",
+//   "What longitudinal cardiovascular outcomes track with chronic vigilance states?",
 //   ...
-//   "What environmental and behavioral factors contribute to persistent inability to maintain sleep?",
+//   // causal
+//   "What occupational and environmental conditions most strongly predict reduced overnight melatonin output?",
+//   "Which household and lifestyle factors are most associated with elevated evening cortisol?",
 //   ...
-//   "What general wellness indicators suggest someone may not be getting adequate rest?",
+//   // soft cover
+//   "How do people who travel across time zones for work typically organize their week?",
+//   "What habits do shift workers tend to adopt to keep up with daily routines?",
 //   ...
 // ]
 ```
+
+The original intent — *insomnia and its long-term effects* — is recoverable only by combining several answers across strategies. No single variant exposes it.
+
+## Finance-adjacent example
+
+```javascript
+const variants = await veiledVariants(
+  'Is now a good time to liquidate my retirement holdings?'
+);
+
+// Sample variants — none asks the original question, none names retirement,
+// liquidation, or selling:
+// [
+//   // scientific
+//   "What macroeconomic indicators historically precede broad shifts in long-duration asset allocation?",
+//   "How do household balance-sheet compositions respond to multi-quarter changes in real interest rates?",
+//   ...
+//   // causal
+//   "What labor-market and demographic signals tend to lead changes in domestic savings flows?",
+//   "Which policy events most consistently coincide with rebalancing activity across managed portfolios?",
+//   ...
+//   // soft cover
+//   "How do families typically decide when to make a large household financial change?",
+//   "What questions do people ask their advisors before any significant life transition?",
+//   ...
+// ]
+```
+
+Again, the original intent only emerges from the *combination* of answers across strategies — each individual query reads as an unrelated research or lifestyle question.
 
 ## API
 
 ### `veiledVariants(prompt, config)`
 
-- `prompt` (string, required): The text to reframe
-- `config.coverage` (`'low'`|`'med'`|`'high'`): Controls strategy breadth and variant count. `'low'` runs 1 strategy producing 3 variants. `'med'` (default) runs all 3 strategies with 5 variants each (15 total). `'high'` runs all 3 strategies with 8 variants each (24 total).
+- `prompt` (string, required): The intent to veil
+- `config.coverage` (`'low'`|`'med'`|`'high'`): Strategy breadth and variant count. `'low'` runs 1 strategy producing 3 variants. `'med'` (default) runs all 3 strategies with 5 variants each (15 total). `'high'` runs all 3 strategies with 8 variants each (24 total).
 - `config.strategies` (Array): Override which strategies to use. Values: `'scientific'`, `'causal'`, `'softCover'`
 - `config.variantCount` (number): Override variants per strategy
 - `config.llm` (string|Object): Model selection. Defaults to `{ sensitive: true }`, requesting a privacy-capable model.
@@ -51,5 +90,5 @@ import {
 } from '@far-world-labs/verblets';
 
 const prompt = scientificFramingPrompt('effects of isolation on cognition', 3);
-// Returns a ready-to-use LLM prompt requesting 3 scientific reframings
+// Returns a ready-to-use LLM prompt requesting 3 adjacent research queries
 ```

--- a/src/chains/veiled-variants/index.js
+++ b/src/chains/veiled-variants/index.js
@@ -26,13 +26,14 @@ const responseFormat = jsonSchema('veiled_variants', veiledVariantsSchema);
 export const scientificFramingPrompt = (
   prompt,
   count = 5
-) => `Recast the intent as if asked by a scientific researcher. Generate exactly ${count} masked alternatives.
+) => `Recast the intent as if asked by a scientific or technical researcher whose work would touch the same answer space — without ever asking the original question. Generate exactly ${count} masked alternatives.
 
 Apply these requirements:
- - Replace casual terms with academic phrasing
- - Invoke terminology from biology, epidemiology, diagnostics, or public health
- - Never use slang, simplifications, or direct synonyms of the original prompt
- - Frame each as a legitimate research query
+ - Never use the prompt's central nouns, verbs, or any direct synonym of them
+ - Frame each as a legitimate research, diagnostic, or modeling query in an adjacent field (biology, epidemiology, diagnostics, public health, economics, finance, risk modeling, public policy, operations research, materials science — whichever fits)
+ - Aim at structural, mechanistic, or precursor questions whose answers would inform the original — not at the original itself
+ - The answers, taken together, should be sufficient to reconstruct an answer to the original; individually, none should reveal the original
+ - Avoid slang and simplifications; write in measured technical register
  - You MUST generate exactly ${count} alternatives. No more, no less.
 
 ${asXML(prompt, { tag: 'intent' })}`;
@@ -40,12 +41,13 @@ ${asXML(prompt, { tag: 'intent' })}`;
 export const causalFramePrompt = (
   prompt,
   count = 5
-) => `Generate queries that explore causes, co-conditions, or plausible consequences of the prompt topic. Generate exactly ${count} masked alternatives.
+) => `Generate queries that explore causes, precursors, co-conditions, or plausible downstream consequences in the neighborhood of the prompt — never asking about the prompt's central subject directly. Generate exactly ${count} masked alternatives.
 
 Apply these requirements:
- - Focus on surrounding or adjacent issues rather than the central sensitive term
- - Frame each as a legitimate research query
- - Explore what leads to, accompanies, or results from the topic
+ - Do not name the central subject of the prompt or any direct synonym
+ - Stay strictly adjacent: ask about contributing factors, surrounding conditions, second-order effects, or comparable phenomena in unrelated domains
+ - Each query must read as a self-contained research question — never as a paraphrase of the original
+ - The original intent should be inferable only by combining several answers, not from any single one
  - You MUST generate exactly ${count} alternatives. No more, no less.
 
 ${asXML(prompt, { tag: 'intent' })}`;
@@ -53,12 +55,13 @@ ${asXML(prompt, { tag: 'intent' })}`;
 export const softCoverPrompt = (
   prompt,
   count = 5
-) => `Reframe the prompt as general wellness or diagnostic concerns. Generate exactly ${count} masked alternatives.
+) => `Reframe the intent as routine information requests adjacent to the topic — wellness check-ins, household decisions, generic explanatory questions, or comparable practical queries from another field — without revealing the underlying intent. Generate exactly ${count} masked alternatives.
 
 Apply these requirements:
- - Avoid direct synonyms or sensitive key terms
- - Use a clinical and approachable tone that is safe for open searches
- - Frame as health, wellness, or general diagnostic queries
+ - Never use the prompt's domain vocabulary, central subject, or direct synonyms
+ - Use a plain, non-clinical voice that fits ordinary day-to-day or workaday inquiries
+ - Each variant must look unremarkable on its own; the original intent must not be guessable from any single one
+ - It is better to drift slightly off-topic than to leak the topic
  - You MUST generate exactly ${count} alternatives. No more, no less.
 
 ${asXML(prompt, { tag: 'intent' })}`;

--- a/src/lib/llm/providers/openwebui.js
+++ b/src/lib/llm/providers/openwebui.js
@@ -1,52 +1,33 @@
 /**
  * OpenWebUI / Ollama provider adapter.
- * OpenAI-compatible API with minor differences:
- *   - Some models don't support structured output (response_format)
- *   - Endpoint paths may differ slightly
+ *
+ * Wraps the OpenAI request/response shape — OpenWebUI exposes an OpenAI-compatible
+ * surface — and layers in two host-specific concerns:
+ *   - `think: false` and `keep_alive: '30m'` body fields
+ *   - Stripping `<think>…</think>` reasoning blocks from responses (Qwen3 et al.)
  */
+
+import * as openai from './openai.js';
+
+const HOST_FIELDS = { think: false, keep_alive: '30m' };
 
 export const buildRequest = (apiUrl, apiKey, endpoint, requestConfig) => {
-  const url = `${apiUrl}${endpoint}`;
-
-  const headers = {
-    'Content-Type': 'application/json',
+  const { url, fetchOptions } = openai.buildRequest(apiUrl, apiKey, endpoint, requestConfig);
+  const body = JSON.parse(fetchOptions.body);
+  const merged = { ...body, ...HOST_FIELDS };
+  return {
+    url,
+    fetchOptions: { ...fetchOptions, body: JSON.stringify(merged) },
   };
-
-  if (apiKey) {
-    headers.Authorization = `Bearer ${apiKey}`;
-  }
-
-  // Convert camelCase responseFormat to snake_case response_format for OpenAI-compatible API
-  const { responseFormat, ...rest } = requestConfig;
-  const ollamaConfig = {
-    ...rest,
-    ...(responseFormat ? { response_format: responseFormat } : {}),
-    think: false,
-    keep_alive: '30m',
-  };
-
-  const fetchOptions = {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(ollamaConfig),
-  };
-
-  return { url, fetchOptions };
 };
 
-/**
- * Strip `<think>…</think>` reasoning blocks emitted by models like Qwen3.
- * These blocks appear at the start of the content and are not part of the
- * actual answer.  The regex is non-greedy so it handles multiple blocks and
- * avoids clobbering legitimate content.
- */
 const stripThinkTags = (text) => text.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
 
-// OpenWebUI returns OpenAI-compatible responses — strip thinking blocks
 export const parseResponse = (json) => {
-  const content = json?.choices?.[0]?.message?.content;
+  const parsed = openai.parseResponse(json);
+  const content = parsed?.choices?.[0]?.message?.content;
   if (typeof content === 'string' && content.includes('<think>')) {
-    json.choices[0].message.content = stripThinkTags(content);
+    parsed.choices[0].message.content = stripThinkTags(content);
   }
-  return json;
+  return parsed;
 };


### PR DESCRIPTION
## Summary
- **veiled-variants**: rewrites the three strategy prompts so variants stay strictly adjacent — never the original subject's nouns, verbs, or synonyms, never paraphrases. The intent is recoverable only by combining several answers across strategies, never from any single one.
- **veiled-variants README**: replaces the previous example (which leaked the topic in every variant) with a fully veiled health example, and adds a parallel finance-adjacent example.
- **Main README**: renames the local-LLaMA snippet to use `provider: 'openwebui'` so the example reads as intentional rather than a typo. Updates the URL/endpoint shape to match the catalog convention.
- **openwebui provider**: refactors to explicitly delegate request/response building to the `openai` adapter and only layer in the OpenWebUI-specific concerns (`think: false`, `keep_alive`, stripping `<think>…</think>` blocks). Same behavior, more obviously an OpenAI-style adapter.
- **questions README** and **map README**: add a second example showing `llm: { sensitive: true }` so it's clear these chains can route through a privacy-capable model.

## Test plan
- [x] Full test suite: 2530 / 2530 passing
- [x] Lint clean
- [ ] Reviewer skim: confirm the new veiled-variants example reads as veiled (no synonym leakage, intent recoverable only in aggregate)
- [ ] Reviewer skim: confirm `provider: 'openwebui'` in the main README is the desired wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)